### PR TITLE
Fix Leapp-created copies of repository config files not generating correctly

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
@@ -13,13 +13,17 @@ from leapp.libraries.common.cl_repofileutils import (
     create_leapp_repofile_copy,
     REPO_DIR,
     REPOFILE_SUFFIX,
+    LEAPP_COPY_SUFFIX
 )
 
 
-def process_repodata(rollout_repodata):
+def process_repodata(rollout_repodata, repofile_name):
     for repo in rollout_repodata.data:
         # On some systems, $releasever gets replaced by a string like "8.6", but we want
         # specifically "8" for rollout repositories - URLs with "8.6" don't exist.
+        # TODO: This is actually because of the releasever being set in Leapp.
+        # Maybe the better option would be to use 8 instead of 8.6 in version string?
+        repo.repoid = repo.repoid + "-8"
         repo.baseurl = repo.baseurl.replace("$releasever", "8")
 
     for repo in rollout_repodata.data:
@@ -32,24 +36,27 @@ def process_repodata(rollout_repodata):
             )
         )
 
-    rollout_reponame = rollout_repodata.file[:-len(REPOFILE_SUFFIX)]
+    resdata = [{repo.repoid: [repo.name, repo.baseurl]} for repo in rollout_repodata.data]
+    api.current_logger().debug("DEBUG REPODATA: {}".format(resdata))
+
+    rollout_reponame = repofile_name[:-len(REPOFILE_SUFFIX)]
     leapp_repocopy_path = create_leapp_repofile_copy(rollout_repodata, rollout_reponame)
     api.produce(CustomTargetRepositoryFile(file=leapp_repocopy_path))
 
 
-def process_repofile(repofile, used_list):
-    full_rollout_repo_path = os.path.join(REPO_DIR, repofile)
+def process_repofile(repofile_name, used_list):
+    full_rollout_repo_path = os.path.join(REPO_DIR, repofile_name)
     rollout_repodata = repofileutils.parse_repofile(full_rollout_repo_path)
 
     # Ignore the repositories (and their files) that are enabled, but have no packages installed from them.
     if not any(repo.repoid in used_list for repo in rollout_repodata.data):
         api.current_logger().debug(
-            "No used repositories found in {}, skipping".format(repofile)
+            "No used repositories found in {}, skipping".format(repofile_name)
         )
         return
 
-    api.current_logger().debug("Rollout file {} has used repositories, adding".format(repofile))
-    process_repodata(rollout_repodata)
+    api.current_logger().debug("Rollout file {} has used repositories, adding".format(repofile_name))
+    process_repodata(rollout_repodata, repofile_name)
 
 
 def process():
@@ -58,12 +65,12 @@ def process():
         for used_repo in used_repos.repositories:
             used_list.append(used_repo.repository)
 
-    for repofile in os.listdir(REPO_DIR):
-        if not is_rollout_repository(repofile):
+    for repofile_name in os.listdir(REPO_DIR):
+        if not is_rollout_repository(repofile_name) or LEAPP_COPY_SUFFIX in repofile_name:
             continue
 
         api.current_logger().debug(
-            "Detected a rollout repository file: {}".format(repofile)
+            "Detected a rollout repository file: {}".format(repofile_name)
         )
 
-        process_repofile(repofile, used_list)
+        process_repofile(repofile_name, used_list)

--- a/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
+++ b/repos/system_upgrade/cloudlinux/actors/scanrolloutrepositories/libraries/scanrolloutrepositories.py
@@ -37,7 +37,7 @@ def process_repodata(rollout_repodata, repofile_name):
         )
 
     resdata = [{repo.repoid: [repo.name, repo.baseurl]} for repo in rollout_repodata.data]
-    api.current_logger().debug("DEBUG REPODATA: {}".format(resdata))
+    api.current_logger().debug("Rollout repository {} repodata: {}".format(repofile_name, resdata))
 
     rollout_reponame = repofile_name[:-len(REPOFILE_SUFFIX)]
     leapp_repocopy_path = create_leapp_repofile_copy(rollout_repodata, rollout_reponame)

--- a/repos/system_upgrade/cloudlinux/libraries/cl_repofileutils.py
+++ b/repos/system_upgrade/cloudlinux/libraries/cl_repofileutils.py
@@ -22,6 +22,13 @@ def create_leapp_repofile_copy(repofile_data, repo_name):
     Create a copy of an existing Yum repository config file, modified
     to be used during the Leapp transaction.
     It will be placed inside the isolated overlay environment Leapp runs the upgrade from.
+
+    :param repofile_data: Data of the repository file copy to be created.
+    :type repofile_data: RepositoryFile
+    :param repo_name: Name of the rollout repository file, without the .repo extension.
+    :type repo_name: str
+    :return: Path to the created copy of the repository file.
+    :rtype: str
     """
     if not os.path.isdir(TEMP_DIR):
         os.makedirs(TEMP_DIR)


### PR DESCRIPTION
The recently introduced mechanism for conditionally generating customized temporary copies of
some yum package repository configs - specifically, CloudLinux Rollout repositories and supported
variants of MySQL/MariaDB - had some flaws in its implementation.

Namely, the files could generate in the wrong folder if the full path to the file was passed instead of the name,
and some repoids could stay the same as with the original repo configs - which would result in the upgrade stopping
due to duplicate repoids being detected.

Both of these issues were fixed.