### PR TITLE
CLOS-2148: skip over enabled rollout repositories with a warning instead of including them

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -42,7 +42,7 @@ py2_byte_compile "%1" "%2"}
 
 Name:           leapp-repository
 Version:        0.16.0
-Release:        2%{?dist}.cloudlinux
+Release:        3%{?dist}.cloudlinux
 Summary:        Repositories for leapp
 
 License:        ASL 2.0

--- a/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
@@ -14,7 +14,7 @@ required_memory = {
     NOPANEL_NAME: 1536 * 1024,  # 1.5 Gb
     UNKNOWN_NAME: 1536 * 1024,  # 1.5 Gb
     INTEGRATED_NAME: 1536 * 1024,  # 1.5 Gb
-    CPANEL_NAME: 2048 * 1024,  # 2 Gb
+    CPANEL_NAME: 1836 * 1024,  # 1.8 Gb
 }
 
 
@@ -52,6 +52,5 @@ def process():
                 reporting.Summary(summary),
                 reporting.Severity(reporting.Severity.HIGH),
                 reporting.Tags([reporting.Tags.SANITY]),
-                reporting.Flags([reporting.Flags.INHIBITOR]),
             ]
         )

--- a/repos/system_upgrade/cloudlinux/actors/clearpackageconflicts/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/clearpackageconflicts/actor.py
@@ -8,29 +8,52 @@ from leapp.models import InstalledRPM
 from leapp.tags import DownloadPhaseTag, IPUWorkflowTag
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
+
 class ClearPackageConflicts(Actor):
     """
     Remove several python package files manually to resolve conflicts between versions of packages to be upgraded.
     """
 
-    name = 'clear_package_conflicts'
+    name = "clear_package_conflicts"
     consumes = (InstalledRPM,)
     produces = ()
     tags = (DownloadPhaseTag.Before, IPUWorkflowTag)
 
     @run_on_cloudlinux
     def process(self):
-        problem_packages = ["alt-python37-six", "alt-python37-pytz"]
-        problem_packages_installed = any([has_package(InstalledRPM, pkg) for pkg in problem_packages])
+        problem_packages = [
+            "alt-python37-six",
+            "alt-python37-pytz",
+        ]
+
+        problem_packages_installed = False
+        for pkg in problem_packages:
+            if has_package(InstalledRPM, pkg):
+                self.log.debug("Conflicting package {} detected".format(pkg))
+                problem_packages_installed = True
+                break
 
         if problem_packages_installed:
             problem_dirs = [
                 "/opt/alt/python37/lib/python3.7/site-packages/six-1.15.0-py3.7.egg-info",
-                "/opt/alt/python37/lib/python3.7/site-packages/pytz-2017.2-py3.7.egg-info"]
+                "/opt/alt/python37/lib/python3.7/site-packages/pytz-2017.2-py3.7.egg-info",
+            ]
+            problem_files = []
+
             for p_dir in problem_dirs:
                 try:
                     if os.path.isdir(p_dir):
                         shutil.rmtree(p_dir)
+                        self.log.debug("Conflicting directory {} removed".format(p_dir))
+                except OSError as e:
+                    if e.errno != errno.ENOENT:
+                        raise
+
+            for p_file in problem_files:
+                try:
+                    if os.path.isfile(p_file):
+                        os.remove(p_file)
+                        self.log.debug("Conflicting file {} removed".format(p_file))
                 except OSError as e:
                     if e.errno != errno.ENOENT:
                         raise

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -110,11 +110,11 @@ def process():
                 # baseurl = https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/
                 # We want to replace the 7 in OS name after /yum/
                 repo.repoid = repo.repoid + '-8'
-                if repo.enabled:
-                    url_parts = repo.baseurl.split('yum')
-                    url_parts[1] = 'yum' + url_parts[1].replace('7', '8')
-                    repo.baseurl = ''.join(url_parts)
+                url_parts = repo.baseurl.split('yum')
+                url_parts[1] = 'yum' + url_parts[1].replace('7', '8')
+                repo.baseurl = ''.join(url_parts)
 
+                if repo.enabled:
                     api.current_logger().debug('Generating custom MariaDB repo: {}'.format(repo.repoid))
                     custom_repo_msgs.append(CustomTargetRepository(
                         repoid=repo.repoid,
@@ -141,6 +141,7 @@ def process():
             for repo in repofile_data.data:
                 # URLs look like this:
                 # baseurl = https://repo.mysql.com/yum/mysql-8.0-community/el/7/x86_64/
+                # Remember that we always want to modify names, to avoid "duplicate repository" errors.
                 repo.repoid = repo.repoid + '-8'
                 repo.baseurl = repo.baseurl.replace('/el/7/', '/el/8/')
 

--- a/repos/system_upgrade/common/actors/checkskippedrepositories/actor.py
+++ b/repos/system_upgrade/common/actors/checkskippedrepositories/actor.py
@@ -46,7 +46,7 @@ class CheckSkippedRepositories(Actor):
                 reporting.Tags([reporting.Tags.REPOSITORY]),
                 reporting.Remediation(
                     hint='You can file a request to add this repository to the scope of in-place upgrades '
-                         'by filing a support ticket')
+                         'by creating a pull request to the cloudlinux/leapp-data GitHub repository')
             ] + packages_related + repos_related)
 
             if config.is_verbose():

--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -214,7 +214,7 @@ def _transaction(context, stage, target_repoids, tasks, plugin_info, test=False,
             api.current_logger().error('Could not call dnf command: Message: %s', str(e), exc_info=True)
             raise StopActorExecutionError(
                 message='Failed to execute dnf. Reason: {}'.format(str(e))
-            )
+            ) from e
         except CalledProcessError as e:
             err_stdout = e.stdout
             err_stderr = e.stderr
@@ -227,7 +227,7 @@ def _transaction(context, stage, target_repoids, tasks, plugin_info, test=False,
                 message='DNF execution failed with non zero exit code.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}'.format(
                     stdout=err_stdout, stderr=err_stderr
                 )
-            )
+            ) from e
         finally:
             if stage == 'check':
                 backup_debug_data(context=context)

--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -214,7 +214,7 @@ def _transaction(context, stage, target_repoids, tasks, plugin_info, test=False,
             api.current_logger().error('Could not call dnf command: Message: %s', str(e), exc_info=True)
             raise StopActorExecutionError(
                 message='Failed to execute dnf. Reason: {}'.format(str(e))
-            ) from e
+            )
         except CalledProcessError as e:
             err_stdout = e.stdout
             err_stderr = e.stderr
@@ -227,7 +227,7 @@ def _transaction(context, stage, target_repoids, tasks, plugin_info, test=False,
                 message='DNF execution failed with non zero exit code.\nSTDOUT:\n{stdout}\nSTDERR:\n{stderr}'.format(
                     stdout=err_stdout, stderr=err_stderr
                 )
-            ) from e
+            )
         finally:
             if stage == 'check':
                 backup_debug_data(context=context)

--- a/repos/system_upgrade/el7toel8/actors/updateyumvars/libraries/updateyumvars.py
+++ b/repos/system_upgrade/el7toel8/actors/updateyumvars/libraries/updateyumvars.py
@@ -2,22 +2,23 @@ import os
 
 from leapp.libraries.stdlib import api
 
-VAR_FOLDER = "/etc/yum/vars"
+VAR_FOLDERS = ["/etc/yum/vars", "/etc/dnf/vars/"]
 
 
 def vars_update():
     """ Iterate through and modify the variables. """
-    if not os.path.isdir(VAR_FOLDER):
-        api.current_logger().debug(
-            "The {} directory doesn't exist. Nothing to do.".format(VAR_FOLDER)
-        )
-        return
+    for var_folder in VAR_FOLDERS:
+        if not os.path.isdir(var_folder):
+            api.current_logger().debug(
+                "The {} directory doesn't exist. Skipping to next.".format(var_folder)
+            )
+            continue
 
-    for varfile_name in os.listdir(VAR_FOLDER):
-        # cp_centos_major_version contains the current OS' major version.
-        if varfile_name == 'cp_centos_major_version':
-            varfile_path = os.path.join(VAR_FOLDER, varfile_name)
+        for varfile_name in os.listdir(var_folder):
+            # cp_centos_major_version contains the current OS' major version.
+            if varfile_name == 'cp_centos_major_version':
+                varfile_path = os.path.join(var_folder, varfile_name)
 
-            with open(varfile_path, 'w') as varfile:
-                # Overwrite the value from outdated "7".
-                varfile.write('8')
+                with open(varfile_path, 'w') as varfile:
+                    # Overwrite the value from outdated "7".
+                    varfile.write('8')


### PR DESCRIPTION
Also multiple smaller improvements not linked to tasks, see commits