### PR TITLE
Modify the migration logic for MySQL variants

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/actor.py
@@ -1,6 +1,6 @@
 from leapp.actors import Actor
 from leapp.reporting import Report
-from leapp.libraries.actor import clmysqlrepositorysetup
+from leapp.libraries.actor.clmysqlrepositorysetup import MySqlRepositorySetupLibrary
 from leapp.models import (
     CustomTargetRepository,
     CustomTargetRepositoryFile,
@@ -32,4 +32,5 @@ class ClMysqlRepositorySetup(Actor):
 
     @run_on_cloudlinux
     def process(self):
-        clmysqlrepositorysetup.process()
+        mysql_reposetup = MySqlRepositorySetupLibrary()
+        mysql_reposetup.process()

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -6,7 +6,7 @@ from leapp.models import (
     CustomTargetRepository,
     RpmTransactionTasks,
     InstalledRPM,
-    Module
+    Module,
 )
 from leapp.libraries.stdlib import api
 from leapp.libraries.common import repofileutils
@@ -19,10 +19,11 @@ from leapp.libraries.common.cl_repofileutils import (
     REPOFILE_SUFFIX,
 )
 
-CL_MARKERS = ['cl-mysql', 'cl-mariadb', 'cl-percona']
-MARIA_MARKERS = ['MariaDB']
-MYSQL_MARKERS = ['mysql-community']
-OLD_MYSQL_VERSIONS = ['5.7', '5.6', '5.5']
+CL_MARKERS = ["cl-mysql", "cl-mariadb", "cl-percona"]
+MARIA_MARKERS = ["MariaDB"]
+MYSQL_MARKERS = ["mysql-community"]
+OLD_CLMYSQL_VERSIONS = ["5.0", "5.1"]
+OLD_MYSQL_UPSTREAM_VERSIONS = ["5.7", "5.6", "5.5"]
 
 
 def build_install_list(prefix):
@@ -37,208 +38,279 @@ def build_install_list(prefix):
     if prefix:
         for rpm_pkgs in api.consume(InstalledRPM):
             for pkg in rpm_pkgs.items:
-                if (pkg.name.startswith(prefix)):
+                if pkg.name.startswith(prefix):
                     to_upgrade.append(pkg.name)
-        api.current_logger().debug('cl-mysql packages to upgrade: {}'.format(to_upgrade))
+        api.current_logger().debug("cl-mysql packages to upgrade: {}".format(to_upgrade))
     return to_upgrade
 
 
-def process():
-    mysql_types = set()
-    clmysql_type = None
-    custom_repo_msgs = []
+class MySqlRepositorySetupLibrary(object):
+    """
+    Detect the various MySQL/MariaDB variants that may be installed on the system
+    and prepare the repositories for the target system.
+    Not all configurations can be handled by normal static Leapp configurations,
+    so we need custom code to handle them.
+    """
 
-    for repofile_full in os.listdir(REPO_DIR):
-        # Don't touch non-repository files or copied repofiles created by Leapp.
-        if repofile_full.endswith(LEAPP_COPY_SUFFIX) or not repofile_full.endswith(REPOFILE_SUFFIX):
-            continue
-        # Cut the .repo part to get only the name.
-        repofile_name = repofile_full[:-len(REPOFILE_SUFFIX)]
-        full_repo_path = os.path.join(REPO_DIR, repofile_full)
+    def __init__(self):
+        self.mysql_types = set()
+        self.clmysql_type = None
+        # Messages to send about custom generated package repositories.
+        self.custom_repo_msgs = []
 
-        # Parse any repository files that may have something to do with MySQL or MariaDB.
-        api.current_logger().debug('Processing repofile {}, full path: {}'.format(repofile_full, full_repo_path))
+    def clmysql_process(self, repofile_name, repofile_data):
+        """
+        Process CL-provided MySQL options.
+        """
+        data_to_log = [
+            (repo_data.repoid, "enabled" if repo_data.enabled else "disabled") for repo_data in repofile_data.data
+        ]
 
-        # Process CL-provided options.
-        if any(mark in repofile_name for mark in CL_MARKERS):
-            repofile_data = repofileutils.parse_repofile(full_repo_path)
-            data_to_log = [
-                (repo_data.repoid, "enabled" if repo_data.enabled else "disabled")
-                for repo_data in repofile_data.data
-            ]
+        api.current_logger().debug("repoids from CloudLinux repofile {}: {}".format(repofile_name, data_to_log))
 
-            api.current_logger().debug('repoids from CloudLinux repofile {}: {}'.format(repofile_name, data_to_log))
+        # Were any repositories enabled?
+        for repo in repofile_data.data:
+            # cl-mysql URLs look like this:
+            # baseurl=http://repo.cloudlinux.com/other/cl$releasever/mysqlmeta/cl-mariadb-10.3/$basearch/
+            # We don't want any duplicate repoid entries.
+            repo.repoid = repo.repoid + "-8"
+            # releasever may be something like 8.6, while only 8 is acceptable.
+            repo.baseurl = repo.baseurl.replace("/cl$releasever/", "/cl8/")
 
-            # Were any repositories enabled?
-            for repo in repofile_data.data:
-                # cl-mysql URLs look like this:
-                # baseurl=http://repo.cloudlinux.com/other/cl$releasever/mysqlmeta/cl-mariadb-10.3/$basearch/
-                # We don't want any duplicate repoid entries.
-                repo.repoid = repo.repoid + '-8'
-                # releasever may be something like 8.6, while only 8 is acceptable.
-                repo.baseurl = repo.baseurl.replace('/cl$releasever/', '/cl8/')
+            # Old CL MySQL versions (5.0 and 5.1) won't be available in CL8.
+            if any(ver in repo.baseurl for ver in OLD_CLMYSQL_VERSIONS):
+                reporting.create_report(
+                    [
+                        reporting.Title("An old CL-MySQL version will no longer be available in EL8"),
+                        reporting.Summary(
+                            "A an old CloudLinux-provided MySQL version is installed on this system. "
+                            "It will no longer be available on the target system. "
+                            "This situation cannot be automatically resolved by Leapp. "
+                            "Problematic repository: {0}".format(repo.repoid)
+                        ),
+                        reporting.Severity(reporting.Severity.MEDIUM),
+                        reporting.Tags([reporting.Tags.REPOSITORY]),
+                        reporting.Flags([reporting.Flags.INHIBITOR]),
+                        reporting.Remediation(
+                            hint=(
+                                "Upgrade to a more recent MySQL version, or"
+                                "uninstall the deprecated MySQL packages and disable the repository."
+                            )
+                        ),
+                    ]
+                )
 
-                # mysqlclient is usually disabled when installed from CL MySQL Governor.
-                # However, it should be enabled for the Leapp upgrade, seeing as some packages
-                # from it won't update otherwise.
-                if repo.enabled or repo.repoid == 'mysqclient-8':
-                    clmysql_type = get_clmysql_type()
-                    api.current_logger().debug('Generating custom cl-mysql repo: {}'.format(repo.repoid))
-                    custom_repo_msgs.append(CustomTargetRepository(
+            # mysqlclient is usually disabled when installed from CL MySQL Governor.
+            # However, it should be enabled for the Leapp upgrade, seeing as some packages
+            # from it won't update otherwise.
+            if repo.enabled or repo.repoid == "mysqclient-8":
+                self.clmysql_type = get_clmysql_type()
+                api.current_logger().debug("Generating custom cl-mysql repo: {}".format(repo.repoid))
+                self.custom_repo_msgs.append(
+                    CustomTargetRepository(
                         repoid=repo.repoid,
                         name=repo.name,
                         baseurl=repo.baseurl,
                         enabled=True,
-                    ))
+                    )
+                )
 
-            if any(repo.enabled for repo in repofile_data.data):
-                mysql_types.add('cloudlinux')
-                leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
-                api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-            else:
-                api.current_logger().debug("No repos from CloudLinux repofile {} enabled, ignoring".format(
-                        repofile_name
-                    ))
+        if any(repo.enabled for repo in repofile_data.data):
+            self.mysql_types.add("cloudlinux")
+            leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
+            api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
+        else:
+            api.current_logger().debug("No repos from CloudLinux repofile {} enabled, ignoring".format(repofile_name))
 
-        # Process MariaDB options.
-        elif any(mark in repofile_name for mark in MARIA_MARKERS):
-            repofile_data = repofileutils.parse_repofile(full_repo_path)
+    def mariadb_process(self, repofile_name, repofile_data):
+        """
+        Process upstream MariaDB options.
 
-            for repo in repofile_data.data:
-                # Maria URLs look like this:
-                # baseurl = https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64
-                # baseurl = https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/
-                # We want to replace the 7 in OS name after /yum/
-                repo.repoid = repo.repoid + '-8'
-                url_parts = repo.baseurl.split('yum')
-                url_parts[1] = 'yum' + url_parts[1].replace('7', '8')
-                repo.baseurl = ''.join(url_parts)
+        Versions of MariaDB installed from https://mariadb.org/.
+        """
 
-                if repo.enabled:
-                    api.current_logger().debug('Generating custom MariaDB repo: {}'.format(repo.repoid))
-                    custom_repo_msgs.append(CustomTargetRepository(
+        for repo in repofile_data.data:
+            # Maria URLs look like this:
+            # baseurl = https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64
+            # baseurl = https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/
+            # We want to replace the 7 in OS name after /yum/
+            repo.repoid = repo.repoid + "-8"
+            url_parts = repo.baseurl.split("yum")
+            url_parts[1] = "yum" + url_parts[1].replace("7", "8")
+            repo.baseurl = "".join(url_parts)
+
+            if repo.enabled:
+                api.current_logger().debug("Generating custom MariaDB repo: {}".format(repo.repoid))
+                self.custom_repo_msgs.append(
+                    CustomTargetRepository(
                         repoid=repo.repoid,
                         name=repo.name,
                         baseurl=repo.baseurl,
                         enabled=repo.enabled,
-                    ))
+                    )
+                )
 
-            if any(repo.enabled for repo in repofile_data.data):
-                # Since MariaDB URLs have major versions written in, we need a new repo file
-                # to feed to the target userspace.
-                mysql_types.add('mariadb')
-                leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
-                api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-            else:
-                api.current_logger().debug("No repos from MariaDB repofile {} enabled, ignoring".format(
-                        repofile_name
-                    ))
+        if any(repo.enabled for repo in repofile_data.data):
+            # Since MariaDB URLs have major versions written in, we need a new repo file
+            # to feed to the target userspace.
+            self.mysql_types.add("mariadb")
+            leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
+            api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
+        else:
+            api.current_logger().debug("No repos from MariaDB repofile {} enabled, ignoring".format(repofile_name))
 
-        # Process MySQL options.
-        elif any(mark in repofile_name for mark in MYSQL_MARKERS):
-            repofile_data = repofileutils.parse_repofile(full_repo_path)
+    def mysql_process(self, repofile_name, repofile_data):
+        """
+        Process upstream MySQL options.
 
-            for repo in repofile_data.data:
-                # URLs look like this:
-                # baseurl = https://repo.mysql.com/yum/mysql-8.0-community/el/7/x86_64/
-                # Remember that we always want to modify names, to avoid "duplicate repository" errors.
-                repo.repoid = repo.repoid + '-8'
-                repo.baseurl = repo.baseurl.replace('/el/7/', '/el/8/')
+        Versions of MySQL installed from https://mysql.com/.
+        """
 
-                if repo.enabled:
-                    # MySQL package repos don't have these versions available for EL8 anymore.
-                    # There'll be nothing to upgrade to.
-                    # CL repositories do provide them, though.
-                    if any(ver in repo.name for ver in OLD_MYSQL_VERSIONS):
-                        reporting.create_report([
-                            reporting.Title('An old MySQL version will no longer be available in EL8'),
+        for repo in repofile_data.data:
+            # URLs look like this:
+            # baseurl = https://repo.mysql.com/yum/mysql-8.0-community/el/7/x86_64/
+            # Remember that we always want to modify names, to avoid "duplicate repository" errors.
+            repo.repoid = repo.repoid + "-8"
+            repo.baseurl = repo.baseurl.replace("/el/7/", "/el/8/")
+
+            if repo.enabled:
+                # MySQL package repos don't have these versions available for EL8 anymore.
+                # There's only 8.0 available.
+                # There'll be nothing to upgrade to.
+                # CL repositories do provide them, though.
+                if any(ver in repo.name for ver in OLD_MYSQL_UPSTREAM_VERSIONS):
+                    reporting.create_report(
+                        [
+                            reporting.Title("An old MySQL version will no longer be available in EL8"),
                             reporting.Summary(
-                                'A yum repository for an old MySQL version is enabled on this system. '
-                                'It will no longer be available on the target system. '
-                                'This situation cannot be automatically resolved by Leapp. '
-                                'Problematic repository: {0}'.format(repo.repoid)
+                                "A yum repository for an old MySQL version is enabled on this system. "
+                                "It will no longer be available on the target system. "
+                                "This situation cannot be automatically resolved by Leapp. "
+                                "Problematic repository: {0}".format(repo.repoid)
                             ),
                             reporting.Severity(reporting.Severity.MEDIUM),
                             reporting.Tags([reporting.Tags.REPOSITORY]),
                             reporting.Flags([reporting.Flags.INHIBITOR]),
-                            reporting.Remediation(hint=(
-                                'Upgrade to a more recent MySQL version, '
-                                'uninstall the deprecated MySQL packages and disable the repository, '
-                                'or switch to CloudLinux MySQL Governor-provided version of MySQL to continue using '
-                                'the old MySQL version.'
+                            reporting.Remediation(
+                                hint=(
+                                    "Upgrade to a more recent MySQL version, "
+                                    "uninstall the deprecated MySQL packages and disable the repository, "
+                                    "or switch to CloudLinux MySQL Governor-provided version of MySQL to "
+                                    "continue using the old MySQL version."
                                 )
-                            )
-                        ])
-                    api.current_logger().debug('Generating custom MySQL repo: {}'.format(repo.repoid))
-                    custom_repo_msgs.append(CustomTargetRepository(
+                            ),
+                        ]
+                    )
+                api.current_logger().debug("Generating custom MySQL repo: {}".format(repo.repoid))
+                self.custom_repo_msgs.append(
+                    CustomTargetRepository(
                         repoid=repo.repoid,
                         name=repo.name,
                         baseurl=repo.baseurl,
                         enabled=repo.enabled,
-                    ))
-
-            if any(repo.enabled for repo in repofile_data.data):
-                # MySQL typically has multiple repo files, so we want to make sure we're
-                # adding the type to list only once.
-                mysql_types.add('mysql')
-                leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
-                api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-            else:
-                api.current_logger().debug("No repos from MySQL repofile {} enabled, ignoring".format(
-                        repofile_name
-                    ))
-
-    if len(mysql_types) == 0:
-        api.current_logger().debug('No installed MySQL/MariaDB detected')
-    else:
-        reporting.create_report([
-            reporting.Title('MySQL database backup recommended'),
-            reporting.Summary(
-                'A MySQL/MariaDB installation has been detected on this machine. '
-                'It is recommended to make a database backup before proceeding with the upgrade.'
-            ),
-            reporting.Severity(reporting.Severity.HIGH),
-            reporting.Tags([reporting.Tags.REPOSITORY]),
-        ])
-
-        for msg in custom_repo_msgs:
-            api.produce(msg)
-
-        if len(mysql_types) == 1:
-            api.current_logger().debug(
-                "Detected MySQL/MariaDB type: {}, version: {}".format(
-                    list(mysql_types)[0], clmysql_type
+                    )
                 )
-            )
+
+        if any(repo.enabled for repo in repofile_data.data):
+            # MySQL typically has multiple repo files, so we want to make sure we're
+            # adding the type to list only once.
+            self.mysql_types.add("mysql")
+            leapp_repocopy = create_leapp_repofile_copy(repofile_data, repofile_name)
+            api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
         else:
-            api.current_logger().warning('Detected multiple MySQL types: {}'.format(", ".join(mysql_types)))
-            reporting.create_report([
-                reporting.Title('Multpile MySQL/MariaDB versions detected'),
-                reporting.Summary(
-                    'Package repositories for multiple distributions of MySQL/MariaDB '
-                    'were detected on the system. '
-                    'Leapp will attempt to update all distributions detected. '
-                    'To update only the distribution you use, disable YUM package repositories for all '
-                    'other distributions. '
-                    'Detected: {0}'.format(", ".join(mysql_types))
-                ),
-                reporting.Severity(reporting.Severity.MEDIUM),
-                reporting.Tags([reporting.Tags.REPOSITORY, reporting.Tags.OS_FACTS]),
-            ])
+            api.current_logger().debug("No repos from MySQL repofile {} enabled, ignoring".format(repofile_name))
 
-    if 'cloudlinux' in mysql_types and clmysql_type in MODULE_STREAMS.keys():
-        mod_name, mod_stream = MODULE_STREAMS[clmysql_type].split(':')
-        modules_to_enable = [Module(name=mod_name, stream=mod_stream)]
-        pkg_prefix = get_pkg_prefix(clmysql_type)
+    def finalize(self):
+        """Use the data collected to produce messages and reports."""
+        if len(self.mysql_types) == 0:
+            api.current_logger().debug("No installed MySQL/MariaDB detected")
+        else:
+            reporting.create_report(
+                [
+                    reporting.Title("MySQL database backup recommended"),
+                    reporting.Summary(
+                        "A MySQL/MariaDB installation has been detected on this machine. "
+                        "It is recommended to make a database backup before proceeding with the upgrade."
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Tags([reporting.Tags.REPOSITORY]),
+                ]
+            )
 
-        api.current_logger().debug('Enabling DNF module: {}:{}'.format(mod_name, mod_stream))
-        api.produce(RpmTransactionTasks(
-                to_upgrade=build_install_list(pkg_prefix),
-                modules_to_enable=modules_to_enable
+            for msg in self.custom_repo_msgs:
+                api.produce(msg)
+
+            if len(self.mysql_types) == 1:
+                api.current_logger().debug(
+                    "Detected MySQL/MariaDB type: {}, version: {}".format(list(self.mysql_types)[0], self.clmysql_type)
+                )
+            else:
+                api.current_logger().warning("Detected multiple MySQL types: {}".format(", ".join(self.mysql_types)))
+                reporting.create_report(
+                    [
+                        reporting.Title("Multpile MySQL/MariaDB versions detected"),
+                        reporting.Summary(
+                            "Package repositories for multiple distributions of MySQL/MariaDB "
+                            "were detected on the system. "
+                            "Leapp will attempt to update all distributions detected. "
+                            "To update only the distribution you use, disable YUM package repositories for all "
+                            "other distributions. "
+                            "Detected: {0}".format(", ".join(self.mysql_types))
+                        ),
+                        reporting.Severity(reporting.Severity.MEDIUM),
+                        reporting.Tags([reporting.Tags.REPOSITORY, reporting.Tags.OS_FACTS]),
+                    ]
+                )
+
+        if "cloudlinux" in self.mysql_types and self.clmysql_type in MODULE_STREAMS.keys():
+            mod_name, mod_stream = MODULE_STREAMS[self.clmysql_type].split(":")
+            modules_to_enable = [Module(name=mod_name, stream=mod_stream)]
+            pkg_prefix = get_pkg_prefix(self.clmysql_type)
+
+            api.current_logger().debug("Enabling DNF module: {}:{}".format(mod_name, mod_stream))
+            api.produce(
+                RpmTransactionTasks(to_upgrade=build_install_list(pkg_prefix), modules_to_enable=modules_to_enable)
+            )
+
+        api.produce(
+            InstalledMySqlTypes(
+                types=list(self.mysql_types),
+                version=self.clmysql_type,
             )
         )
 
-    api.produce(InstalledMySqlTypes(
-        types=list(mysql_types),
-        version=clmysql_type,
-    ))
+    def process(self):
+        """Main processing function."""
+
+        for repofile_full in os.listdir(REPO_DIR):
+            # Don't touch non-repository files or copied repofiles created by Leapp.
+            if repofile_full.endswith(LEAPP_COPY_SUFFIX) or not repofile_full.endswith(REPOFILE_SUFFIX):
+                continue
+            # Cut the .repo part to get only the name.
+            repofile_name = repofile_full[: -len(REPOFILE_SUFFIX)]
+            full_repo_path = os.path.join(REPO_DIR, repofile_full)
+            repofile_data = repofileutils.parse_repofile(full_repo_path)
+
+            # Parse any repository files that may have something to do with MySQL or MariaDB.
+
+            if any(mark in repofile_name for mark in CL_MARKERS):
+                api.current_logger().debug(
+                    "Processing CL-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
+                )
+                self.clmysql_process(repofile_name, repofile_data)
+
+            # Process MariaDB options.
+            elif any(mark in repofile_name for mark in MARIA_MARKERS):
+                api.current_logger().debug(
+                    "Processing MariaDB-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
+                )
+                self.mariadb_process(repofile_name, repofile_data)
+
+            # Process MySQL options.
+            elif any(mark in repofile_name for mark in MYSQL_MARKERS):
+                api.current_logger().debug(
+                    "Processing MySQL-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
+                )
+                self.mysql_process(repofile_name, repofile_data)
+
+        self.finalize()

--- a/repos/system_upgrade/cloudlinux/actors/switchclnchannel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/switchclnchannel/actor.py
@@ -23,14 +23,11 @@ class SwitchClnChannel(Actor):
     def process(self):
         switch_cmd = [self.switch_bin, "-t", "8", "-o", "-f"]
         yum_clean_cmd = ["yum", "clean", "all"]
-        update_release_cmd = ["yum", "update", "-y", "cloudlinux-release"]
         try:
             res = run(switch_cmd)
             self.log.debug('Command "%s" result: %s', switch_cmd, res)
             res = run(yum_clean_cmd)  # required to update the repolist
             self.log.debug('Command "%s" result: %s', yum_clean_cmd, res)
-            res = run(update_release_cmd)
-            self.log.debug('Command "%s" result: %s', update_release_cmd, res)
         except CalledProcessError as e:
             reporting.create_report(
                 [

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -37,7 +37,10 @@ def get_pkg_prefix(clmysql_type):
 
 
 def get_clmysql_type():
+    """
+    Get the currently active MySQL type from the Governor configuration file.
+    """
     if os.path.isfile(CL7_MYSQL_TYPE_FILE):
-        with open(CL7_MYSQL_TYPE_FILE, "r") as mysql_f:
+        with open(CL7_MYSQL_TYPE_FILE, "r", encoding="utf-8") as mysql_f:
             return mysql_f.read()
     return None


### PR DESCRIPTION
* Block on old CL-MySQL versions
* Modify the custom repository generation to create files correctly for all MySQL versions
* Remove the cloudlinux-release early update which interfered with other components of the upgrade