### PR TITLE
Fix upgrade on systems with private root mountpoint and multiple partitions

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -42,7 +42,7 @@ py2_byte_compile "%1" "%2"}
 
 Name:           leapp-repository
 Version:        0.16.0
-Release:        7%{?dist}.cloudlinux
+Release:        8%{?dist}.cloudlinux
 Summary:        Repositories for leapp
 
 License:        ASL 2.0

--- a/repos/system_upgrade/common/libraries/mounting.py
+++ b/repos/system_upgrade/common/libraries/mounting.py
@@ -33,6 +33,16 @@ class MountingMode(object):
     """ Used when no actual mount call needs to be issued """
 
 
+class MountingPropagation(object):
+    """
+    MountingPropagation are types of mounts propagation supported by the library
+    """
+    PRIVATE = 'private'
+    """ Used for private propagation mounts """
+    SHARED = 'shared'
+    """ Used for shared propagation mounts """
+
+
 def _makedirs(path, mode=0o777, exists_ok=True):
     """ Helper function which extends os.makedirs with exists_ok on all versions of python. """
     try:
@@ -293,11 +303,14 @@ class MountConfig(object):
 class MountingBase(object):
     """ Base class for all mount operations """
 
-    def __init__(self, source, target, mode, config=MountConfig.Mount):
+    def __init__(self, source, target, mode,
+                 config=MountConfig.Mount,
+                 propagation=MountingPropagation.SHARED):
         self._mode = mode
         self.source = source
         self.target = target
         self._config = config
+        self.propagation = propagation
         self.additional_directories = ()
 
     def _mount_options(self):
@@ -305,7 +318,17 @@ class MountingBase(object):
         Options to use with the mount call, individual implementations may override this function to return the
         correct parameters
         """
-        return ['-o', self._mode, self.source]
+        return [
+            '-o', self._mode,
+            '--make-' + self.propagation,
+            self.source
+        ]
+
+    def _umount_options(self):
+        """
+        Options to use with the umount call.
+        """
+        return ['-fl']
 
     def chroot(self):
         """ Create a ChrootActions instance for this mount """
@@ -323,7 +346,7 @@ class MountingBase(object):
         """ Cleanup operations """
         if os.path.exists(self.target) and os.path.ismount(self.target):
             try:
-                run(['umount', '-fl', self.target], split=False)
+                run(['umount'] + self._umount_options() + [self.target], split=False)
             except (OSError, CalledProcessError) as e:
                 api.current_logger().warning('Unmounting %s failed with: %s', self.target, str(e))
         for directory in itertools.chain(self.additional_directories, (self.target,)):
@@ -404,6 +427,7 @@ class TypedMount(MountingBase):
     def _mount_options(self):
         return [
             '-t', self.fstype,
+            '--make-' + self.propagation,
             self.source
         ]
 
@@ -421,5 +445,6 @@ class OverlayMount(MountingBase):
     def _mount_options(self):
         return [
             '-t', 'overlay', 'overlay2',
+            '--make-' + self.propagation,
             '-o', 'lowerdir={},upperdir={},workdir={}'.format(self.source, self._upper_dir, self._work_dir)
         ]

--- a/repos/system_upgrade/common/libraries/overlaygen.py
+++ b/repos/system_upgrade/common/libraries/overlaygen.py
@@ -222,6 +222,12 @@ def create_source_overlay(mounts_dir, scratch_dir, xfs_info, storage_info, mount
         _create_mounts_dir(scratch_dir, mounts_dir)
         mounts = _prepare_required_mounts(scratch_dir, mounts_dir, _get_mountpoints(storage_info), xfs_info)
         with mounts.pop('/') as root_mount:
+            # it's important to make system_overlay shared because we
+            # later mount it into mount_target with some tricky way:
+            #  1. create system_overlay mount
+            #  2. mount system_overlay to mount_target (e.g. installroot)
+            #  3. mount other mounts like /tmp, /usr inside system_overlay
+            # if at stage 3 system_overlay is not shared, mounts will not appear in `mount_target`
             with mounting.OverlayMount(name='system_overlay', source='/', workdir=root_mount.target) as root_overlay:
                 if mount_target:
                     target = mounting.BindMount(source=root_overlay.target, target=mount_target)


### PR DESCRIPTION
This proposed change fixes upgrades on CloudLinux systems with multiple partitions.

Before this change, upgrade exited with "Can not load RPM file" error if server had multiple partitions mounted on CloudLinux.
```
Can not load RPM file: /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/leapp-deps-el8-5.0.8-0.202403281153Z.c18549c5.HEAD.el8.noarch.rpm.
Can not load RPM file: /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/leapp-repository-deps-el8-5.0.8-0.202403281153Z.c18549c5.HEAD.el8.noarch.rpm.
Can not load RPM file: /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/kernel-workaround-0.1-1.el8.noarch.rpm.
Could not open: /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/leapp-deps-el8-5.0.8-0.202403281153Z.c18549c5.HEAD.el8.noarch.rpm /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/leapp-repository-deps-el8-5.0.8-0.202403281153Z.c18549c5.HEAD.el8.noarch.rpm /installroot/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/files/bundled-rpms/kernel-workaround-0.1-1.el8.noarch.rpm
```

This error happened because leapp is expecting mounts to be **shared** when it creates installroot in overlayfs and it's true for CentOS-based systems, but not for CloudLinux, where mounts are remounted as **private** on boot.

As a result, some mounts were missing in installroot.

CentOS:
```
├─/var/lib/leapp/el8userspace/installroot                                                       overlay2                                                                   overlay     rw,relatime,lowerdir=/,upperdir=/var/lib/leapp/scratch/mounts/root_/upper,workdir=/var/lib/leapp/scratch/mounts/root_/work
│ ├─/var/lib/leapp/el8userspace/installroot/tmp                                                 overlay2                                                                   overlay     rw,relatime,lowerdir=/tmp,upperdir=/var/lib/leapp/scratch/mounts/root_tmp/upper,workdir=/var/lib/leapp/scratch/mounts/root_tmp/work
│ ├─/var/lib/leapp/el8userspace/installroot/usr                                                 overlay2                                                                   overlay     rw,relatime,lowerdir=/usr,upperdir=/var/lib/leapp/scratch/mounts/root_usr/upper,workdir=/var/lib/leapp/scratch/mounts/root_usr/work
│ └─/var/lib/leapp/el8userspace/installroot/var/cache/dnf                                       /dev/sda1[/var/cache/dnf]                                                  ext4        rw,relatime,data=ordered,jqfmt=vfsv1,usrjquota=quota.user
```

CloudLinux:
```
└─/var/lib/leapp/el8userspace/installroot                                                       overlay2                                                                   overlay     rw,relatime,lowerdir=/,upperdir=/var/lib/leapp/scratch/mounts/root_/upper,workdir=/var/lib/leapp/scratch/mounts/root_/work
```

This patch explicitely adds --make-shared argument to mount which results in shared mounts creation during elevation:
```
[root@vm-id-2050710 ~]# findmnt -o TARGET,PROPAGATION
TARGET                                                                                          PROPAGATION
/                                                                                               private
├─/sys                                                                                          private
...
├─/var/lve/dbgovernor-shm                                                                       private
├─/var/lib/nfs/rpc_pipefs                                                                       private
├─/tmp                                                                                          private
├─/var/tmp                                                                                      private
├─/var/lib/leapp/scratch/mounts/root_/system_overlay                                            shared
│ ├─/var/lib/leapp/scratch/mounts/root_/system_overlay/tmp                                      shared
│ ├─/var/lib/leapp/scratch/mounts/root_/system_overlay/usr                                      shared
│ ├─/var/lib/leapp/scratch/mounts/root_/system_overlay/var/cache/dnf                            shared
│ └─/var/lib/leapp/scratch/mounts/root_/system_overlay/el8target                                shared
├─/var/lib/leapp/scratch/mounts/root_tmp/root_tmp                                               shared
└─/var/lib/leapp/scratch/mounts/root_usr/root_usr                                               shared
```

As a result, overlayfs creation also succedes and upgrade works as it would work on regular CentOS.
```
├─/tmp                                                                                          private
├─/var/tmp                                                                                      private
├─/var/lib/leapp/scratch/mounts/root_/system_overlay                                            shared
│ ├─/var/lib/leapp/scratch/mounts/root_/system_overlay/tmp                                      shared
│ ├─/var/lib/leapp/scratch/mounts/root_/system_overlay/usr                                      shared
│ └─/var/lib/leapp/scratch/mounts/root_/system_overlay/var/cache/dnf                            shared
├─/var/lib/leapp/el8userspace/installroot                                                       shared
│ ├─/var/lib/leapp/el8userspace/installroot/tmp                                                 shared
│ ├─/var/lib/leapp/el8userspace/installroot/usr                                                 shared
│ └─/var/lib/leapp/el8userspace/installroot/var/cache/dnf                                       shared
├─/var/lib/leapp/scratch/mounts/root_tmp/root_tmp                                               shared
└─/var/lib/leapp/scratch/mounts/root_usr/root_usr                                               shared
```


This patch fixes CLOS-2565 and also probably [RHEL-23449](https://issues.redhat.com/browse/RHEL-23449).