### PR TITLE
Adding basic DirectAdmin elevation support

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
+++ b/repos/system_upgrade/cloudlinux/actors/checkpanelmemory/libraries/checkpanelmemory.py
@@ -8,12 +8,14 @@ from leapp.libraries.common.detectcontrolpanel import (
     UNKNOWN_NAME,
     INTEGRATED_NAME,
     CPANEL_NAME,
+    DIRECTADMIN_NAME,
 )
 
 required_memory = {
     NOPANEL_NAME: 1536 * 1024,  # 1.5 Gb
     UNKNOWN_NAME: 1536 * 1024,  # 1.5 Gb
     INTEGRATED_NAME: 1536 * 1024,  # 1.5 Gb
+    DIRECTADMIN_NAME: 1536 * 1024,  # 1.5 Gb
     CPANEL_NAME: 1836 * 1024,  # 1.8 Gb
 }
 

--- a/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/detectcontrolpanel/actor.py
@@ -11,6 +11,7 @@ from leapp.libraries.common.detectcontrolpanel import (
     UNKNOWN_NAME,
     INTEGRATED_NAME,
     CPANEL_NAME,
+    DIRECTADMIN_NAME
 )
 
 
@@ -30,8 +31,8 @@ class DetectControlPanel(Actor):
         if panel is None:
             raise StopActorExecutionError(message=("Missing information about the installed web panel."))
 
-        if panel.name == CPANEL_NAME:
-            self.log.debug('cPanel detected, upgrade proceeding')
+        if panel.name in (CPANEL_NAME, DIRECTADMIN_NAME):
+            self.log.debug('%s detected, upgrade proceeding' % panel.name)
         elif panel.name == INTEGRATED_NAME or panel.name == UNKNOWN_NAME or panel.name == NOPANEL_NAME:
             self.log.debug('Integrated/no panel detected, upgrade proceeding')
         elif panel:


### PR DESCRIPTION
This change is fixing obvious blockers of DirectAdmin elevation:

- added mininal memory requirements constant
- removed inhivitor which prevents DirectAdmin upgrade

The upgrade is still experimental and other issues may appear.