### PR TITLE
Add safe grub embedded space inhibitor

### DIFF
--- a/repos/system_upgrade/common/actors/checkgrubcore/actor.py
+++ b/repos/system_upgrade/common/actors/checkgrubcore/actor.py
@@ -45,11 +45,16 @@ class CheckGrubCore(Actor):
                 create_report([
                     reporting.Title('Leapp could not identify where GRUB core is located'),
                     reporting.Summary(
-                        'We assume GRUB core is located on the same device as /boot. Leapp needs to '
-                        'update GRUB core as it is not done automatically on legacy (BIOS) systems. '
+                        'We assumed GRUB2 core is located on the same device(s) as /boot, '
+                        'however Leapp could not detect GRUB2 on those device(s). '
+                        'This means GRUB2 core will not be updated during the upgrade process and '
+                        'the system will probably ' 'boot into the old kernel after the upgrade. '
+                        'GRUB2 core needs to be updated manually on legacy (BIOS) systems to '
+                        'fix this.'
                     ),
                     reporting.Severity(reporting.Severity.HIGH),
                     reporting.Tags([reporting.Tags.BOOT]),
                     reporting.Remediation(
-                        hint='Please run "grub2-install <GRUB_DEVICE> command manually after upgrade'),
+                        hint='Please run the "grub2-install <GRUB_DEVICE>" command manually '
+                        'after the upgrade'),
                 ])

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/actor.py
@@ -1,0 +1,24 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import check_first_partition_offset
+from leapp.models import FirmwareFacts, GRUBDevicePartitionLayout
+from leapp.reporting import Report
+from leapp.tags import ChecksPhaseTag, IPUWorkflowTag
+
+
+class CheckFirstPartitionOffset(Actor):
+    """
+    Check whether the first partition starts at the offset >=1MiB.
+
+    The alignment of the first partition plays role in disk access speeds. Older tools placed the start of the first
+    partition at cylinder 63 (due to historical reasons connected to the INT13h BIOS API). However, grub core
+    binary is placed before the start of the first partition, meaning that not enough space causes bootloader
+    installation to fail. Modern partitioning tools place the first partition at >= 1MiB (cylinder 2048+).
+    """
+
+    name = 'check_first_partition_offset'
+    consumes = (FirmwareFacts, GRUBDevicePartitionLayout,)
+    produces = (Report,)
+    tags = (ChecksPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        check_first_partition_offset.check_first_partition_offset()

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
@@ -1,0 +1,52 @@
+from leapp import reporting
+from leapp.libraries.common.config import architecture
+from leapp.libraries.stdlib import api
+from leapp.models import FirmwareFacts, GRUBDevicePartitionLayout
+
+SAFE_OFFSET_BYTES = 1024*1024  # 1MiB
+
+
+def check_first_partition_offset():
+    if architecture.matches_architecture(architecture.ARCH_S390X):
+        return
+
+    for fact in api.consume(FirmwareFacts):
+        if fact.firmware == 'efi':
+            return  # Skip EFI system
+
+    problematic_devices = []
+    for grub_dev in api.consume(GRUBDevicePartitionLayout):
+        first_partition = min(grub_dev.partitions, key=lambda partition: partition.start_offset)
+        if first_partition.start_offset < SAFE_OFFSET_BYTES:
+            problematic_devices.append(grub_dev.device)
+
+    if problematic_devices:
+        summary = (
+            'On the system booting by using BIOS, the in-place upgrade fails '
+            'when upgrading the GRUB2 bootloader if the boot disk\'s embedding area '
+            'does not contain enough space for the core image installation. '
+            'This results in a broken system, and can occur when the disk has been '
+            'partitioned manually, for example using the RHEL 6 fdisk utility.\n\n'
+
+            'The list of devices with small embedding area:\n'
+            '{0}.'
+        )
+        problematic_devices_fmt = ['- {0}'.format(dev) for dev in problematic_devices]
+
+        hint = (
+            'We recommend to perform a fresh installation of the RHEL 8 system '
+            'instead of performing the in-place upgrade.\n'
+            'Another possibility is to reformat the devices so that there is '
+            'at least {0} kiB space before the first partition. '
+            'Note that this operation is not supported and does not have to be '
+            'always possible.'
+        )
+
+        reporting.create_report([
+            reporting.Title('Found GRUB devices with too little space reserved before the first partition'),
+            reporting.Summary(summary.format('\n'.join(problematic_devices_fmt))),
+            reporting.Remediation(hint=hint.format(SAFE_OFFSET_BYTES // 1024)),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.BOOT]),
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
@@ -16,6 +16,13 @@ def check_first_partition_offset():
 
     problematic_devices = []
     for grub_dev in api.consume(GRUBDevicePartitionLayout):
+        if not grub_dev.partitions:
+            # NOTE(pstodulk): In case of empty partition list we have nothing to do.
+            # This can could happen when the fdisk output is different then expected.
+            # E.g. when GPT partition table is used on the disk. We are right now
+            # interested strictly about MBR only, so ignoring these cases.
+            # This is seatbelt, as the msg should not be produced for GPT at all.
+            continue
         first_partition = min(grub_dev.partitions, key=lambda partition: partition.start_offset)
         if first_partition.start_offset < SAFE_OFFSET_BYTES:
             problematic_devices.append(grub_dev.device)

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
@@ -54,6 +54,6 @@ def check_first_partition_offset():
             reporting.Summary(summary.format('\n'.join(problematic_devices_fmt))),
             reporting.Remediation(hint=hint.format(SAFE_OFFSET_BYTES // 1024)),
             reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.BOOT]),
-            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Tags([reporting.Tags.BOOT]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
         ])

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
@@ -44,7 +44,9 @@ def check_first_partition_offset():
             'We recommend to perform a fresh installation of the RHEL 8 system '
             'instead of performing the in-place upgrade.\n'
             'Another possibility is to reformat the devices so that there is '
-            'at least {0} kiB space before the first partition. '
+            'at least {0} kiB space before the first partition. If reformatting the drive is not possible, '
+            'consider migrating your /boot folder and grub2 configuration to another drive '
+            '(refer to https://cloudlinux.zendesk.com/hc/en-us/articles/14549594244508)'
             'Note that this operation is not supported and does not have to be '
             'always possible.'
         )

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/libraries/check_first_partition_offset.py
@@ -46,7 +46,7 @@ def check_first_partition_offset():
             'Another possibility is to reformat the devices so that there is '
             'at least {0} kiB space before the first partition. If reformatting the drive is not possible, '
             'consider migrating your /boot folder and grub2 configuration to another drive '
-            '(refer to https://cloudlinux.zendesk.com/hc/en-us/articles/14549594244508)'
+            '(refer to https://cloudlinux.zendesk.com/hc/en-us/articles/14549594244508). '
             'Note that this operation is not supported and does not have to be '
             'always possible.'
         )

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/tests/test_check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/tests/test_check_first_partition_offset.py
@@ -1,0 +1,51 @@
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import check_first_partition_offset
+from leapp.libraries.common import grub
+from leapp.libraries.common.testutils import create_report_mocked, CurrentActorMocked
+from leapp.libraries.stdlib import api
+from leapp.models import FirmwareFacts, GRUBDevicePartitionLayout, PartitionInfo
+from leapp.reporting import Report
+from leapp.utils.report import is_inhibitor
+
+
+@pytest.mark.parametrize(
+    ('devices', 'should_report'),
+    [
+        (
+            [
+                GRUBDevicePartitionLayout(device='/dev/vda',
+                                          partitions=[PartitionInfo(part_device='/dev/vda1', start_offset=32256)])
+            ],
+            True
+        ),
+        (
+            [
+                GRUBDevicePartitionLayout(device='/dev/vda',
+                                          partitions=[PartitionInfo(part_device='/dev/vda1', start_offset=1024*1025)])
+            ],
+            False
+        ),
+        (
+            [
+                GRUBDevicePartitionLayout(device='/dev/vda',
+                                          partitions=[PartitionInfo(part_device='/dev/vda1', start_offset=1024*1024)])
+            ],
+            False
+        )
+    ]
+)
+def test_bad_offset_reported(monkeypatch, devices, should_report):
+    def consume_mocked(model_cls):
+        if model_cls == FirmwareFacts:
+            return [FirmwareFacts(firmware='bios')]
+        return devices
+
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked())
+    monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+
+    check_first_partition_offset.check_first_partition_offset()
+
+    assert bool(reporting.create_report.called) == should_report

--- a/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/tests/test_check_first_partition_offset.py
+++ b/repos/system_upgrade/el7toel8/actors/checkfirstpartitionoffset/tests/test_check_first_partition_offset.py
@@ -23,6 +23,16 @@ from leapp.utils.report import is_inhibitor
         (
             [
                 GRUBDevicePartitionLayout(device='/dev/vda',
+                                          partitions=[
+                                            PartitionInfo(part_device='/dev/vda2', start_offset=1024*1025),
+                                            PartitionInfo(part_device='/dev/vda1', start_offset=32256)
+                                          ])
+            ],
+            True
+        ),
+        (
+            [
+                GRUBDevicePartitionLayout(device='/dev/vda',
                                           partitions=[PartitionInfo(part_device='/dev/vda1', start_offset=1024*1025)])
             ],
             False
@@ -31,6 +41,12 @@ from leapp.utils.report import is_inhibitor
             [
                 GRUBDevicePartitionLayout(device='/dev/vda',
                                           partitions=[PartitionInfo(part_device='/dev/vda1', start_offset=1024*1024)])
+            ],
+            False
+        ),
+        (
+            [
+                GRUBDevicePartitionLayout(device='/dev/vda', partitions=[])
             ],
             False
         )

--- a/repos/system_upgrade/el7toel8/actors/checklegacygrub/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/checklegacygrub/actor.py
@@ -1,0 +1,20 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import check_legacy_grub as check_legacy_grub_lib
+from leapp.reporting import Report
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class CheckLegacyGrub(Actor):
+    """
+    Check whether GRUB Legacy is installed in the MBR.
+
+    GRUB Legacy is deprecated since RHEL 7 in favour of GRUB2.
+    """
+
+    name = 'check_grub_legacy'
+    consumes = ()
+    produces = (Report,)
+    tags = (FactsPhaseTag, IPUWorkflowTag)
+
+    def process(self):
+        check_legacy_grub_lib.check_grub_disks_for_legacy_grub()

--- a/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
+++ b/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
@@ -1,0 +1,71 @@
+from leapp import reporting
+from leapp.exceptions import StopActorExecution
+from leapp.libraries.common import grub as grub_lib
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.reporting import create_report
+
+# There is no grub legacy package on RHEL7, therefore, the system must have been upgraded from RHEL6
+MIGRATION_TO_GRUB2_GUIDE_URL = 'https://access.redhat.com/solutions/2643721'
+
+
+def has_legacy_grub(device):
+    try:
+        output = run(['file', '-s', device])
+    except CalledProcessError as err:
+        msg = 'Failed to determine the file type for the special device `{0}`. Full error: `{1}`'
+        api.current_logger().warning(msg.format(device, str(err)))
+
+        # According to `file` manpage, the exit code > 0 iff the file does not exists (meaning)
+        # that grub_lib.get_grub_devices() is unreliable for some reason (better stop the upgrade),
+        # or because the file type could not be determined. However, its manpage directly gives examples
+        # of file -s being used on block devices, so this should be unlikely - especially if one would
+        # consider that get_grub_devices was able to determine that it is a grub device.
+        raise StopActorExecution()
+
+    grub_legacy_version_string = 'GRUB version 0.94'
+    return grub_legacy_version_string in output['stdout']
+
+
+def check_grub_disks_for_legacy_grub():
+    # Both GRUB2 and Grub Legacy are recognized by `get_grub_devices`
+    grub_devices = grub_lib.get_grub_devices()
+
+    legacy_grub_devices = []
+    for device in grub_devices:
+        if has_legacy_grub(device):
+            legacy_grub_devices.append(device)
+
+    if legacy_grub_devices:
+        details = (
+            'Leapp detected GRUB Legacy to be installed on the system. '
+            'The GRUB Legacy bootloader is unsupported on RHEL7 and GRUB2 must be used instead. '
+            'The presence of GRUB Legacy is possible on systems that have been upgraded from RHEL 6 in the past, '
+            'but required manual post-upgrade steps have not been performed. '
+            'Note that the in-place upgrade from RHEL 6 to RHEL 7 systems is in such a case '
+            'considered as unfinished.\n\n'
+
+            'GRUB Legacy has been detected on following devices:\n'
+            '{block_devices_fmt}\n'
+        )
+
+        hint = (
+            'Migrate to the GRUB2 bootloader on the reported devices. '
+            'Also finish other post-upgrade steps related to the previous in-place upgrade, the majority of which '
+            'is a part of the related preupgrade report for upgrades from RHEL 6 to RHEL 7.'
+            'If you are not sure whether all previously required post-upgrade steps '
+            'have been performed, consider a clean installation of the RHEL 8 system instead. '
+            'Note that the in-place upgrade to RHEL 8 can fail in various ways '
+            'if the RHEL 7 system is misconfigured.'
+        )
+
+        block_devices_fmt = '\n'.join(legacy_grub_devices)
+        create_report([
+            reporting.Title("GRUB Legacy is used on the system"),
+            reporting.Summary(details.format(block_devices_fmt=block_devices_fmt)),
+            reporting.Severity(reporting.Severity.HIGH),
+            reporting.Groups([reporting.Groups.BOOT]),
+            reporting.Remediation(hint=hint),
+            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.ExternalLink(url=MIGRATION_TO_GRUB2_GUIDE_URL,
+                                   title='How to install GRUB2 after a RHEL6 to RHEL7 upgrade'),
+        ])

--- a/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
+++ b/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
@@ -28,7 +28,13 @@ def has_legacy_grub(device):
 
 def check_grub_disks_for_legacy_grub():
     # Both GRUB2 and Grub Legacy are recognized by `get_grub_devices`
-    grub_devices = grub_lib.get_grub_devices()
+    # oshyshatskyi: newer versions of leapp support multiple grub devices e.g. for raid
+    # because our version does not support that, we always check only one device
+    # https://github.com/oamg/leapp-repository/commit/2ba44076625e35aabfd2a1f9e45b2934f99f1e8d
+    grub_device = grub_lib.get_grub_device()
+    grub_devices = []
+    if grub_device:
+        grub_devices.append(grub_device)
 
     legacy_grub_devices = []
     for device in grub_devices:

--- a/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
+++ b/repos/system_upgrade/el7toel8/actors/checklegacygrub/libraries/check_legacy_grub.py
@@ -63,9 +63,9 @@ def check_grub_disks_for_legacy_grub():
             reporting.Title("GRUB Legacy is used on the system"),
             reporting.Summary(details.format(block_devices_fmt=block_devices_fmt)),
             reporting.Severity(reporting.Severity.HIGH),
-            reporting.Groups([reporting.Groups.BOOT]),
+            reporting.Tags([reporting.Tags.BOOT]),
             reporting.Remediation(hint=hint),
-            reporting.Groups([reporting.Groups.INHIBITOR]),
+            reporting.Flags([reporting.Flags.INHIBITOR]),
             reporting.ExternalLink(url=MIGRATION_TO_GRUB2_GUIDE_URL,
                                    title='How to install GRUB2 after a RHEL6 to RHEL7 upgrade'),
         ])

--- a/repos/system_upgrade/el7toel8/actors/checklegacygrub/tests/test_check_legacy_grub.py
+++ b/repos/system_upgrade/el7toel8/actors/checklegacygrub/tests/test_check_legacy_grub.py
@@ -1,0 +1,45 @@
+import pytest
+
+from leapp.libraries.actor import check_legacy_grub as check_legacy_grub_lib
+from leapp.libraries.common import grub as grub_lib
+from leapp.libraries.common.testutils import create_report_mocked
+from leapp.utils.report import is_inhibitor
+
+VDA_WITH_LEGACY_GRUB = (
+    '/dev/vda: x86 boot sector; GRand Unified Bootloader, stage1 version 0x3, '
+    'stage2 address 0x2000, stage2 segment 0x200, GRUB version 0.94; partition 1: ID=0x83, '
+    'active, starthead 32, startsector 2048, 1024000 sectors; partition 2: ID=0x83, starthead 221, '
+    'startsector 1026048, 19945472 sectors, code offset 0x48\n'
+)
+
+NVME0N1_VDB_WITH_GRUB = (
+    '/dev/nvme0n1: x86 boot sector; partition 1: ID=0x83, active, starthead 32, startsector 2048, 6291456 sectors; '
+    'partition 2: ID=0x83, starthead 191, startsector 6293504, 993921024 sectors, code offset 0x63'
+)
+
+
+@pytest.mark.parametrize(
+    ('grub_device_to_file_output', 'should_inhibit'),
+    [
+        ({'/dev/vda': VDA_WITH_LEGACY_GRUB}, True),
+        ({'/dev/nvme0n1': NVME0N1_VDB_WITH_GRUB}, False),
+        ({'/dev/vda': VDA_WITH_LEGACY_GRUB, '/dev/nvme0n1': NVME0N1_VDB_WITH_GRUB}, True)
+    ]
+)
+def test_check_legacy_grub(monkeypatch, grub_device_to_file_output, should_inhibit):
+
+    def file_cmd_mock(cmd, *args, **kwargs):
+        assert cmd[:2] == ['file', '-s']
+        return {'stdout': grub_device_to_file_output[cmd[2]]}
+
+    monkeypatch.setattr(check_legacy_grub_lib, 'create_report', create_report_mocked())
+    monkeypatch.setattr(grub_lib, 'get_grub_devices', lambda: list(grub_device_to_file_output.keys()))
+    monkeypatch.setattr(check_legacy_grub_lib, 'run', file_cmd_mock)
+
+    check_legacy_grub_lib.check_grub_disks_for_legacy_grub()
+
+    assert bool(check_legacy_grub_lib.create_report.called) == should_inhibit
+    if should_inhibit:
+        assert len(check_legacy_grub_lib.create_report.reports) == 1
+        report = check_legacy_grub_lib.create_report.reports[0]
+        assert is_inhibitor(report)

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/actor.py
@@ -1,0 +1,18 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import scan_layout as scan_layout_lib
+from leapp.models import GRUBDevicePartitionLayout, GrubInfo
+from leapp.tags import FactsPhaseTag, IPUWorkflowTag
+
+
+class ScanGRUBDevicePartitionLayout(Actor):
+    """
+    Scan all identified GRUB devices for their partition layout.
+    """
+
+    name = 'scan_grub_device_partition_layout'
+    consumes = (GrubInfo,)
+    produces = (GRUBDevicePartitionLayout,)
+    tags = (FactsPhaseTag, IPUWorkflowTag,)
+
+    def process(self):
+        scan_layout_lib.scan_grub_device_partition_layout()

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/actor.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/actor.py
@@ -10,7 +10,7 @@ class ScanGRUBDevicePartitionLayout(Actor):
     """
 
     name = 'scan_grub_device_partition_layout'
-    consumes = (GrubInfo,)
+    consumes = ()
     produces = (GRUBDevicePartitionLayout,)
     tags = (FactsPhaseTag, IPUWorkflowTag,)
 

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
@@ -1,0 +1,64 @@
+from leapp.libraries.stdlib import api, CalledProcessError, run
+from leapp.models import GRUBDevicePartitionLayout, GrubInfo, PartitionInfo
+
+SAFE_OFFSET_BYTES = 1024*1024  # 1MiB
+
+
+def split_on_space_segments(line):
+    fragments = (fragment.strip() for fragment in line.split(' '))
+    return [fragment for fragment in fragments if fragment]
+
+
+def get_partition_layout(device):
+    try:
+        partition_table = run(['fdisk', '-l', '-u=sectors', device], split=True)['stdout']
+    except CalledProcessError as err:
+        # Unlikely - if the disk has no partition table, `fdisk` terminates with 0 (no err). Fdisk exits with an err
+        # when the device does not exists, or if it is too small to contain a partition table.
+
+        err_msg = 'Failed to run `fdisk` to obtain the partition table of the device {0}. Full error: \'{1}\''
+        api.current_logger().error(err_msg.format(device, str(err)))
+        return None
+
+    table_iter = iter(partition_table)
+
+    for line in table_iter:
+        if not line.startswith('Units'):
+            # We are still reading general device information and not the table itself
+            continue
+
+        unit = line.split('=')[2].strip()  # Contains '512 bytes'
+        unit = int(unit.split(' ')[0].strip())
+        break  # First line of the partition table header
+
+    for line in table_iter:
+        line = line.strip()
+        if not line.startswith('Device'):
+            continue
+
+        part_all_attrs = split_on_space_segments(line)
+        break
+
+    partitions = []
+    for partition_line in table_iter:
+        # Fields:               Device     Boot   Start      End  Sectors Size Id Type
+        # The line looks like: `/dev/vda1  *       2048  2099199  2097152   1G 83 Linux`
+        part_info = split_on_space_segments(partition_line)
+
+        # If the partition is not bootable, the Boot column might be empty
+        part_device = part_info[0]
+        part_start = int(part_info[2]) if len(part_info) == len(part_all_attrs) else int(part_info[1])
+        partitions.append(PartitionInfo(part_device=part_device, start_offset=part_start*unit))
+
+    return GRUBDevicePartitionLayout(device=device, partitions=partitions)
+
+
+def scan_grub_device_partition_layout():
+    grub_devices = next(api.consume(GrubInfo), None)
+    if not grub_devices:
+        return
+
+    for device in grub_devices.orig_devices:
+        dev_info = get_partition_layout(device)
+        if dev_info:
+            api.produce(dev_info)

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
@@ -1,0 +1,78 @@
+from collections import namedtuple
+
+import pytest
+
+from leapp.libraries.actor import scan_layout as scan_layout_lib
+from leapp.libraries.common import grub
+from leapp.libraries.common.testutils import create_report_mocked, produce_mocked
+from leapp.libraries.stdlib import api
+from leapp.models import GRUBDevicePartitionLayout, GrubInfo
+from leapp.utils.report import is_inhibitor
+
+Device = namedtuple('Device', ['name', 'partitions', 'sector_size'])
+Partition = namedtuple('Partition', ['name', 'start_offset'])
+
+
+@pytest.mark.parametrize(
+    'devices',
+    [
+        (
+            Device(name='/dev/vda', sector_size=512,
+                   partitions=[Partition(name='/dev/vda1', start_offset=63),
+                               Partition(name='/dev/vda2', start_offset=1000)]),
+            Device(name='/dev/vdb', sector_size=1024,
+                   partitions=[Partition(name='/dev/vdb1', start_offset=100),
+                               Partition(name='/dev/vdb2', start_offset=20000)])
+        ),
+        (
+            Device(name='/dev/vda', sector_size=512,
+                   partitions=[Partition(name='/dev/vda1', start_offset=111),
+                               Partition(name='/dev/vda2', start_offset=1000)]),
+        )
+    ]
+)
+def test_get_partition_layout(monkeypatch, devices):
+    device_to_fdisk_output = {}
+    for device in devices:
+        fdisk_output = [
+            'Disk {0}: 42.9 GB, 42949672960 bytes, 83886080 sectors'.format(device.name),
+            'Units = sectors of 1 * {sector_size} = {sector_size} bytes'.format(sector_size=device.sector_size),
+            'Sector size (logical/physical): 512 bytes / 512 bytes',
+            'I/O size (minimum/optimal): 512 bytes / 512 bytes',
+            'Disk label type: dos',
+            'Disk identifier: 0x0000000da',
+            '',
+            '   Device Boot      Start         End      Blocks   Id  System',
+        ]
+        for part in device.partitions:
+            part_line = '{0}   *     {1}     2099199     1048576   83  Linux'.format(part.name, part.start_offset)
+            fdisk_output.append(part_line)
+
+        device_to_fdisk_output[device.name] = fdisk_output
+
+    def mocked_run(cmd, *args, **kwargs):
+        assert cmd[:3] == ['fdisk', '-l', '-u=sectors']
+        device = cmd[3]
+        output = device_to_fdisk_output[device]
+        return {'stdout': output}
+
+    def consume_mocked(*args, **kwargs):
+        yield GrubInfo(orig_devices=[device.name for device in devices])
+
+    monkeypatch.setattr(scan_layout_lib, 'run', mocked_run)
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+    monkeypatch.setattr(api, 'consume', consume_mocked)
+
+    scan_layout_lib.scan_grub_device_partition_layout()
+
+    assert api.produce.called == len(devices)
+
+    dev_name_to_desc = {dev.name: dev for dev in devices}
+
+    for message in api.produce.model_instances:
+        assert isinstance(message, GRUBDevicePartitionLayout)
+        dev = dev_name_to_desc[message.device]
+
+        expected_part_name_to_start = {part.name: part.start_offset*dev.sector_size for part in dev.partitions}
+        actual_part_name_to_start = {part.part_device: part.start_offset for part in message.partitions}
+        assert expected_part_name_to_start == actual_part_name_to_start

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
@@ -76,3 +76,8 @@ def test_get_partition_layout(monkeypatch, devices):
         expected_part_name_to_start = {part.name: part.start_offset*dev.sector_size for part in dev.partitions}
         actual_part_name_to_start = {part.part_device: part.start_offset for part in message.partitions}
         assert expected_part_name_to_start == actual_part_name_to_start
+
+
+def test_get_partition_layout_gpt(monkeypatch):
+    # TODO(pstodulk): skipping for now, due to time pressure. Testing for now manually.
+    pass

--- a/repos/system_upgrade/el7toel8/models/partitionlayout.py
+++ b/repos/system_upgrade/el7toel8/models/partitionlayout.py
@@ -1,0 +1,28 @@
+from leapp.models import fields, Model
+from leapp.topics import SystemInfoTopic
+
+
+class PartitionInfo(Model):
+    """
+    Information about a single partition.
+    """
+    topic = SystemInfoTopic
+
+    part_device = fields.String()
+    """ Partition device """
+
+    start_offset = fields.Integer()
+    """ Partition start - offset from the start of the block device in bytes """
+
+
+class GRUBDevicePartitionLayout(Model):
+    """
+    Information about partition layout of a GRUB device.
+    """
+    topic = SystemInfoTopic
+
+    device = fields.String()
+    """ GRUB device """
+
+    partitions = fields.List(fields.Model(PartitionInfo))
+    """ List of partitions present on the device """


### PR DESCRIPTION
This PR cherry-picks changes from upstream that:

- add inhibitor for legacy grub (NOT grub2)
- add inhibitor for old disk partitions which do not have enough space for grub2 installation.

Both changes should decrease amount of machines that are "briked" during elevation.