### PR TITLE
CLOS-2786: Fix detection when a bootable partition in on RAID

### DIFF
--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py
@@ -65,7 +65,6 @@ def get_partition_layout(device):
         if not line.startswith('Device'):
             continue
 
-        part_all_attrs = split_on_space_segments(line)
         break
 
     partitions = []
@@ -76,7 +75,7 @@ def get_partition_layout(device):
 
         # If the partition is not bootable, the Boot column might be empty
         part_device = part_info[0]
-        part_start = int(part_info[2]) if len(part_info) == len(part_all_attrs) else int(part_info[1])
+        part_start = int(part_info[2]) if part_info[1] == '*' else int(part_info[1])
         partitions.append(PartitionInfo(part_device=part_device, start_offset=part_start*unit))
 
     return GRUBDevicePartitionLayout(device=device, partitions=partitions)

--- a/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
+++ b/repos/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/tests/test_scan_partition_layout.py
@@ -31,7 +31,8 @@ Partition = namedtuple('Partition', ['name', 'start_offset'])
         )
     ]
 )
-def test_get_partition_layout(monkeypatch, devices):
+@pytest.mark.parametrize('fs', ('Linux', 'Linux raid autodetect'))
+def test_get_partition_layout(monkeypatch, devices, fs):
     device_to_fdisk_output = {}
     for device in devices:
         fdisk_output = [
@@ -45,7 +46,7 @@ def test_get_partition_layout(monkeypatch, devices):
             '   Device Boot      Start         End      Blocks   Id  System',
         ]
         for part in device.partitions:
-            part_line = '{0}   *     {1}     2099199     1048576   83  Linux'.format(part.name, part.start_offset)
+            part_line = '{0}   *     {1}     2099199     1048576   83  {2}'.format(part.name, part.start_offset, fs)
             fdisk_output.append(part_line)
 
         device_to_fdisk_output[device.name] = fdisk_output


### PR DESCRIPTION
On my server, leapp preupgrade fail with the following error:

	Traceback (most recent call last):
	  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
	    self.run()
	  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
	    self._target(*self._args, **self._kwargs)
	  File "/usr/lib/python2.7/site-packages/leapp/repository/actor_definition.py", line 74, in _do_run
	    actor_instance.run(*args, **kwargs)
	  File "/usr/lib/python2.7/site-packages/leapp/actors/__init__.py", line 289, in run
	    self.process(*args)
	  File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/actor.py", line 18, in process
	    scan_layout_lib.scan_grub_device_partition_layout()
	  File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py", line 91, in scan_grub_device_partition_layout
	    dev_info = get_partition_layout(device)
	  File "/usr/share/leapp-repository/repositories/system_upgrade/el7toel8/actors/scangrubdevpartitionlayout/libraries/scan_layout.py", line 79, in get_partition_layout
	    part_start = int(part_info[2]) if len(part_info) == len(part_all_attrs) else int(part_info[1])
	ValueError: invalid literal for int() with base 10: '*'

This is caused by the following line:

	/dev/sda1   *        2048     1026047      512000   fd  Linux raid autodetect

I have my server on EL7 with / using a Linux RAID so len(part_info) != len(part_all_attrs), hence why it try to convert '*' to int.