### PR TITLE
Change certain DNF command failures to throw StopActorExecutionError …

### DIFF
--- a/repos/system_upgrade/common/libraries/dnfconfig.py
+++ b/repos/system_upgrade/common/libraries/dnfconfig.py
@@ -105,9 +105,16 @@ def _set_excluded_pkgs(context, pkglist, disable_plugins):
 
     try:
         context.call(cmd)
-    except CalledProcessError:
+    except CalledProcessError as e:
         api.current_logger().error('Cannot set the dnf configuration')
-        raise
+        raise StopActorExecutionError(
+            message='Cannot set the DNF configuration with the command: {}'.format(cmd),
+            details={
+                'details': 'An exception raised: {}'.format(str(e)),
+                'stdout': e.stdout,
+                'stderr': e.stderr
+            }
+        )
     api.current_logger().debug('The DNF configuration has been updated to exclude leapp packages.')
 
 
@@ -147,7 +154,14 @@ def _set_repository_state(context, repo_id, new_state):
 
     try:
         context.call(cmd)
-    except CalledProcessError:
+    except CalledProcessError as e:
         api.current_logger().error('Cannot set the dnf configuration')
-        raise
+        raise StopActorExecutionError(
+            message='Cannot set the DNF configuration with the command: {}'.format(cmd),
+            details={
+                'details': 'An exception raised: {}'.format(str(e)),
+                'stdout': e.stdout,
+                'stderr': e.stderr
+            }
+        )
     api.current_logger().debug('Repository {} has been {}'.format(repo_id, new_state))


### PR DESCRIPTION
…error instead of CalledProcessError

When certain DNF commands fail, an unhandled CalledProcessError is thrown, halting the process and preventing cleanup actors from executing during preupgrade. Replacing it with StopActorExecutionError ensures the process still fails but executes the required actors.