### PR TITLE
Fix upstream mariadb upgrade

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -228,9 +228,9 @@ class MySqlRepositorySetupLibrary(object):
                 if str(source_major) == "8" and any(ver in target_repo.baseurl for ver in OLD_MARIADB_UPSTREAM_VERSIONS_CL8):
                     reporting.create_report(
                         [
-                            reporting.Title("MariaDB is not compatible with Leapp upgrade"),
+                            reporting.Title("MariaDB version is not compatible with Leapp upgrade"),
                             reporting.Summary(
-                                "MariaDB is enabled on this system but is not compatible with Leapp upgrade process. "
+                                "MariaDB is installed on this system but is's version is not compatible with Leapp upgrade process. "
                                 "The upgrade is blocked to prevent system instability. "
                                 "This situation cannot be automatically resolved by Leapp. "
                                 "Problematic repository: {0}".format(target_repo.repoid)

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -195,7 +195,7 @@ class MySqlRepositorySetupLibrary(object):
         # Replace the first occurrence of source_major with target_major after 'yum'
         url_parts = mariadb_url.split("yum", 1)
         if len(url_parts) == 2:
-            # Replace major version in "/centos/7/" and /yum/12.0/almalinux9-amd64/,
+            # Replace major version in "/centos/7/" and /12.0/almalinux9-amd64/,
             # but do not replace it in /mariadb-10.7/yum/
             url_parts[1] = url_parts[1].replace("/{}/".format(source_major), "/{}/".format(target_major))
             url_parts[1] = url_parts[1].replace("{}-".format(source_major), "{}-".format(target_major))
@@ -204,7 +204,6 @@ class MySqlRepositorySetupLibrary(object):
             url_parts[1] = url_parts[1].replace('$releasever', str(target_major))
             return "yum".join(url_parts)
         else:
-            # TODO: fix in https://cloudlinux.atlassian.net/browse/CLOS-3490
             api.current_logger().warning("Unsupported repository URL={}, skipping".format(mariadb_url))
             return
 
@@ -230,7 +229,7 @@ class MySqlRepositorySetupLibrary(object):
                         [
                             reporting.Title("MariaDB version is not compatible with Leapp upgrade"),
                             reporting.Summary(
-                                "MariaDB is installed on this system but is's version is not compatible with Leapp upgrade process. "
+                                "MariaDB is installed on this system but its version is not compatible with Leapp upgrade process. "
                                 "The upgrade is blocked to prevent system instability. "
                                 "This situation cannot be automatically resolved by Leapp. "
                                 "Problematic repository: {0}".format(target_repo.repoid)

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/tests/test_upgrade_mariadb_community.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/tests/test_upgrade_mariadb_community.py
@@ -1,0 +1,91 @@
+import pytest
+
+from leapp.libraries.actor import clmysqlrepositorysetup
+
+
+@pytest.mark.parametrize(
+    "source_url,source_major,target_major,expected_url",
+    [
+        # Test cases from docstring
+        (
+            "https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64",
+            7, 8,
+            "https://archive.mariadb.org/mariadb-10.3/yum/centos/8/x86_64",
+        ),
+        (
+            "https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/",
+            7, 8,
+            "https://archive.mariadb.org/mariadb-10.7/yum/centos8-ppc64/",
+        ),
+        (
+            "https://distrohub.kyiv.ua/mariadb/yum/11.8/rhel/7/x86_64",
+            7, 8,
+            "https://distrohub.kyiv.ua/mariadb/yum/11.8/rhel/8/x86_64",
+        ),
+        (
+            "https://mariadb.gb.ssimn.org/yum/12.0/centos/7/x86_64",
+            7, 8,
+            "https://mariadb.gb.ssimn.org/yum/12.0/centos/8/x86_64",
+        ),
+        (
+            "https://mariadb.gb.ssimn.org/yum/12.0/almalinux8-amd64/",
+            8, 9,
+            "https://mariadb.gb.ssimn.org/yum/12.0/almalinux9-amd64/",
+        ),
+
+        # Test with trailing slash
+        (
+            "https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64/",
+            7, 8,
+            "https://archive.mariadb.org/mariadb-10.3/yum/centos/8/x86_64/",
+        ),
+
+         # Test cases based on SSIMN.org mirror patterns
+         # RHEL patterns
+         (
+             "https://mariadb.gb.ssimn.org/yum/12.0/rhel8-amd64/",
+             8, 9,
+             "https://mariadb.gb.ssimn.org/yum/12.0/rhel9-amd64/",
+         ),
+
+         # Rocky Linux patterns
+         (
+             "https://mariadb.gb.ssimn.org/yum/12.0/rocky8-amd64/",
+             8, 9,
+             "https://mariadb.gb.ssimn.org/yum/12.0/rocky9-amd64/",
+         ),
+         (
+             "https://mariadb.gb.ssimn.org/yum/12.0/rockylinux8-amd64/",
+             8, 9,
+             "https://mariadb.gb.ssimn.org/yum/12.0/rockylinux9-amd64/",
+         ),
+
+        # Test cases that should return None and log warning
+        (
+            "https://example.com/mariadb/repo/centos/7/x86_64",
+            7, 8,
+            None,
+        ),
+        (
+            "https://example.com/mariadb/yum",
+            7, 8,
+            None,
+        ),
+        (
+            "",
+            7, 8,
+            None,
+        ),
+        (
+            None,
+            7, 8,
+            None,
+        ),
+    ]
+)
+def test_make_upgrade_mariadb_url(source_url, source_major, target_major, expected_url):
+    """Test URL transformation for various MariaDB repository URLs."""
+    library = clmysqlrepositorysetup.MySqlRepositorySetupLibrary()
+    result = library._make_upgrade_mariadb_url(source_url, source_major, target_major)
+
+    assert result == expected_url


### PR DESCRIPTION
This change fixes upstream mariadb upgrade procedure by better baseurl links handling.

Also, upgrades from mariadb 10.3 and 10.4 on CloudLinux 8 are blocked because of the bug in spec which hangs upgrade process .