### PR TITLE
CLOS-3489: Add cl-mysql8.4 and cl-mariadb11.04 to leapp

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/actor.py
@@ -1,16 +1,16 @@
 from leapp.actors import Actor
-from leapp.reporting import Report
 from leapp.libraries.actor.clmysqlrepositorysetup import MySqlRepositorySetupLibrary
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.models import (
     CustomTargetRepository,
     CustomTargetRepositoryFile,
     InstalledMySqlTypes,
-    RpmTransactionTasks,
-    RepositoriesMapping,
     InstalledRPM,
+    RepositoriesMapping,
+    RpmTransactionTasks,
 )
+from leapp.reporting import Report
 from leapp.tags import FactsPhaseTag, IPUWorkflowTag
-from leapp.libraries.common.cllaunch import run_on_cloudlinux
 
 
 class ClMysqlRepositorySetup(Actor):

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -1,29 +1,29 @@
-import os
 import copy
+import os
 
-from leapp.models import (
-    InstalledMySqlTypes,
-    CustomTargetRepositoryFile,
-    CustomTargetRepository,
-    RpmTransactionTasks,
-    InstalledRPM,
-    RepositoriesMapping,
-    RepoMapEntry,
-    PESIDRepositoryEntry,
-    Module,
-)
-from leapp.libraries.stdlib import api
-from leapp.libraries.common import repofileutils
 from leapp import reporting
-from leapp.libraries.common.clmysql import get_clmysql_type, get_pkg_prefix, MODULE_STREAMS
+from leapp.libraries.common import repofileutils
 from leapp.libraries.common.cl_repofileutils import (
-    create_leapp_repofile_copy,
-    REPO_DIR,
     LEAPP_COPY_SUFFIX,
+    REPO_DIR,
     REPOFILE_SUFFIX,
+    create_leapp_repofile_copy,
 )
-from leapp.models import RepositoryFile
+from leapp.libraries.common.clmysql import MODULE_STREAMS, get_clmysql_type, get_pkg_prefix
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    CustomTargetRepository,
+    CustomTargetRepositoryFile,
+    InstalledMySqlTypes,
+    InstalledRPM,
+    Module,
+    PESIDRepositoryEntry,
+    RepoMapEntry,
+    RepositoriesMapping,
+    RepositoryFile,
+    RpmTransactionTasks,
+)
 
 CL_MARKERS = ["cl-mysql", "cl-mariadb", "cl-percona"]
 MARIA_MARKERS = ["MariaDB"]

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -11,6 +11,7 @@ MODULE_STREAMS = {
     "mysql56": "mysql:cl-MySQL56",
     "mysql57": "mysql:cl-MySQL57",
     "mysql80": "mysql:cl-MySQL80",
+    "mysql84": "mysql:cl-MySQL84",
     "mariadb55": "mariadb:cl-MariaDB55",
     "mariadb100": "mariadb:cl-MariaDB100",
     "mariadb101": "mariadb:cl-MariaDB101",
@@ -19,6 +20,7 @@ MODULE_STREAMS = {
     "mariadb104": "mariadb:cl-MariaDB104",
     "mariadb105": "mariadb:cl-MariaDB105",
     "mariadb106": "mariadb:cl-MariaDB106",
+    "mariadb1104": "mariadb:cl-MariaDB1104",
     "percona56": "percona:cl-Percona56",
 }
 

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -1,5 +1,6 @@
 import os
-from leapp.libraries.stdlib import api, run, CalledProcessError
+
+from leapp.libraries.stdlib import CalledProcessError, api, run
 
 # This file contains the data on the currently active MySQL installation type and version.
 CL7_MYSQL_TYPE_FILE = "/usr/share/lve/dbgovernor/mysql.type"


### PR DESCRIPTION
These two new db versions were previously unmapped in the corresponding actor and thus were not upgraded correctly.
It doesn't seem like anything aside from adding the mapping is required.