### PR TITLE
CLOS-3828: Combine repository mappings when setting up target repos

### DIFF
--- a/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
@@ -134,13 +134,13 @@ def process():
         "Vendor repolist: {}".format([repo.repoid for repo in vendor_repos])
     )
 
-    # Setup repomap handler
-    repo_mappig_msg = next(api.consume(RepositoriesMapping), RepositoriesMapping())
+    # Setup repomap handler from combined repomapping message
+    repo_mapping_msg = combine_repomap_messages(repo_mapping_list)
 
     rhui_info = next(api.consume(RHUIInfo), None)
     cloud_provider = rhui_info.provider if rhui_info else ''
 
-    repomap = setuptargetrepos_repomap.RepoMapDataHandler(repo_mappig_msg, cloud_provider=cloud_provider)
+    repomap = setuptargetrepos_repomap.RepoMapDataHandler(repo_mapping_msg, cloud_provider=cloud_provider)
 
     # Filter set of repoids from installed packages so that it contains only repoids with mapping
     repoids_from_installed_packages_with_mapping = _get_mapped_repoids(repomap, repoids_from_installed_packages)


### PR DESCRIPTION
Previously the code only considered a single repomap item - looks like a leftover from upstream, where it's not expected that more than one exists.

In our case it's quite likely, however, due to each vendor having their own repomap that may appear conditionally. Therefore, all available maps need to be merged before usage.