### PR TITLE
CLOS-3833: Add cl-MariaDB1011 to known CL-provided DB versions, improve DB version detection, add unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ PYTEST_ARGS ?=
 PYLINT_ARGS ?=
 FLAKE8_ARGS ?=
 
-# python version to run test with
-_PYTHON_VENV=$${PYTHON_VENV:-python2.7}
+# python version to run tests with — auto-detect from OS major version when not set
+_PYTHON_VENV=$${PYTHON_VENV:-$$(rpm -E %{rhel} 2>/dev/null | grep -qE '^[89]' && echo python3.6 || echo python2.7)}
 
 ifdef ACTOR
 	TEST_PATHS=`$(_PYTHON_VENV) utils/actor_path.py $(ACTOR)`
@@ -292,6 +292,8 @@ install-deps:
 	case $(_PYTHON_VENV) in python3*) yum install -y ${shell echo $(_PYTHON_VENV) | tr -d .}; esac
 	@# in centos:7 python dependencies required gcc
 	case $(_PYTHON_VENV) in python3*) yum install gcc -y; esac
+	@# ensure virtualenv is available (not installed by default on EL8+)
+	command -v virtualenv >/dev/null 2>&1 || pip$$(echo $(_PYTHON_VENV) | sed 's/python//') install virtualenv
 	virtualenv -p /usr/bin/$(_PYTHON_VENV) $(VENVNAME); \
 	. $(VENVNAME)/bin/activate; \
 	pip install -U pip; \

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -409,11 +409,9 @@ class MySqlRepositorySetupLibrary(object):
             if mod_name and mod_stream:
                 if self.clmysql_type not in MODULE_STREAMS:
                     api.current_logger().warning(
-                        "CL database type %s is not in MODULE_STREAMS; using derived DNF module %s:%s. "
-                        "Add an explicit MODULE_STREAMS entry when this stream is product-supported.",
-                        self.clmysql_type,
-                        mod_name,
-                        mod_stream,
+                        "CL database type {} is not in MODULE_STREAMS; using derived DNF module {}:{}. "
+                        "Add an explicit MODULE_STREAMS entry when this stream is product-supported."
+                        .format(self.clmysql_type, mod_name, mod_stream)
                     )
                     reporting.create_report(
                         [
@@ -438,9 +436,9 @@ class MySqlRepositorySetupLibrary(object):
                 )
             else:
                 api.current_logger().warning(
-                    "CL DB package type %s could not be mapped to a DNF module stream; "
-                    "skipping modules_to_enable for CloudLinux DB packages.",
-                    self.clmysql_type,
+                    "CL DB package type {} could not be mapped to a DNF module stream; "
+                    "skipping modules_to_enable for CloudLinux DB packages."
+                    .format(self.clmysql_type)
                 )
                 reporting.create_report(
                     [

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -9,7 +9,12 @@ from leapp.libraries.common.cl_repofileutils import (
     REPOFILE_SUFFIX,
     create_leapp_repofile_copy,
 )
-from leapp.libraries.common.clmysql import MODULE_STREAMS, get_clmysql_type, get_pkg_prefix
+from leapp.libraries.common.clmysql import (
+    MODULE_STREAMS,
+    get_clmysql_type,
+    get_pkg_prefix,
+    resolve_clmysql_module_stream,
+)
 from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.stdlib import api
 from leapp.models import (
@@ -399,15 +404,58 @@ class MySqlRepositorySetupLibrary(object):
                     ]
                 )
 
-        if "cloudlinux" in self.mysql_types and self.clmysql_type in MODULE_STREAMS.keys():
-            mod_name, mod_stream = MODULE_STREAMS[self.clmysql_type].split(":")
-            modules_to_enable = [Module(name=mod_name, stream=mod_stream)]
-            pkg_prefix = get_pkg_prefix(self.clmysql_type)
+        if "cloudlinux" in self.mysql_types and self.clmysql_type:
+            mod_name, mod_stream = resolve_clmysql_module_stream(self.clmysql_type)
+            if mod_name and mod_stream:
+                if self.clmysql_type not in MODULE_STREAMS:
+                    api.current_logger().warning(
+                        "CL database type %s is not in MODULE_STREAMS; using derived DNF module %s:%s. "
+                        "Add an explicit MODULE_STREAMS entry when this stream is product-supported.",
+                        self.clmysql_type,
+                        mod_name,
+                        mod_stream,
+                    )
+                    reporting.create_report(
+                        [
+                            reporting.Title("CloudLinux database module stream was derived automatically"),
+                            reporting.Summary(
+                                "The active CloudLinux MySQL/MariaDB/Percona type ({0}) has no explicit Leapp "
+                                "MODULE_STREAMS entry. Leapp will enable DNF module {1}:{2} derived from the "
+                                "detected type string. If the upgrade fails, confirm this module exists for the "
+                                "target OS and add MODULE_STREAMS in Leapp if the product stream name differs."
+                                .format(self.clmysql_type, mod_name, mod_stream)
+                            ),
+                            reporting.Severity(reporting.Severity.MEDIUM),
+                            reporting.Groups([reporting.Groups.REPOSITORY, reporting.Groups.OS_FACTS]),
+                        ]
+                    )
 
-            api.current_logger().debug("Enabling DNF module: {}:{}".format(mod_name, mod_stream))
-            api.produce(
-                RpmTransactionTasks(to_upgrade=build_install_list(pkg_prefix), modules_to_enable=modules_to_enable)
-            )
+                api.current_logger().debug("Enabling DNF module: {}:{}".format(mod_name, mod_stream))
+                pkg_prefix = get_pkg_prefix(self.clmysql_type)
+                modules_to_enable = [Module(name=mod_name, stream=mod_stream)]
+                api.produce(
+                    RpmTransactionTasks(to_upgrade=build_install_list(pkg_prefix), modules_to_enable=modules_to_enable)
+                )
+            else:
+                api.current_logger().warning(
+                    "CL DB package type %s could not be mapped to a DNF module stream; "
+                    "skipping modules_to_enable for CloudLinux DB packages.",
+                    self.clmysql_type,
+                )
+                reporting.create_report(
+                    [
+                        reporting.Title("Unrecognized CloudLinux DB type for module enablement"),
+                        reporting.Summary(
+                            "A CloudLinux-provided DB repository was detected, but the active type "
+                            "({0}) does not match known MODULE_STREAMS and could not be converted to a DNF module "
+                            "name/stream. Leapp will not enable a DB module automatically; the upgrade "
+                            "may fail unless repositories and modules are corrected manually."
+                            .format(self.clmysql_type)
+                        ),
+                        reporting.Severity(reporting.Severity.HIGH),
+                        reporting.Groups([reporting.Groups.REPOSITORY, reporting.Groups.OS_FACTS]),
+                    ]
+                )
 
         api.produce(
             InstalledMySqlTypes(
@@ -428,8 +476,7 @@ class MySqlRepositorySetupLibrary(object):
             full_repo_path = os.path.join(REPO_DIR, repofile_full)
             repofile_data = repofileutils.parse_repofile(full_repo_path)
 
-            # Parse any repository files that may have something to do with MySQL or MariaDB.
-
+            # Parse any CL repository files that may have something to do with MySQL or MariaDB.
             if any(mark in repofile_name for mark in CL_MARKERS):
                 api.current_logger().debug(
                     "Processing CL-related repofile {}, full path: {}".format(repofile_full, full_repo_path)

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -10,6 +10,7 @@ from leapp.libraries.common.cl_repofileutils import (
     create_leapp_repofile_copy,
 )
 from leapp.libraries.common.clmysql import (
+    ClMysqlTypeStatus,
     MODULE_STREAMS,
     get_clmysql_type,
     get_pkg_prefix,
@@ -106,7 +107,47 @@ class MySqlRepositorySetupLibrary(object):
         """
         Process CL-provided MySQL options.
         """
-        self.clmysql_type = get_clmysql_type()
+        detected = get_clmysql_type()
+
+        if detected.status == ClMysqlTypeStatus.MISMATCH:
+            reporting.create_report(
+                [
+                    reporting.Title(
+                        "Mismatch between Governor DB type and installed packages"
+                    ),
+                    reporting.Summary(
+                        "MySQL Governor records the installed database type as '{governor}', "
+                        "but the mysqld binary on disk belongs to '{rpm}'. "
+                        "This usually means 'mysqlgovernor.py --mysql-version' was run "
+                        "without a follow-up '--install', or packages were changed manually. "
+                        "Proceeding could enable the wrong DNF module stream and break the upgrade.".format(
+                            governor=detected.governor_type, rpm=detected.pkg_type
+                        )
+                    ),
+                    reporting.Severity(reporting.Severity.HIGH),
+                    reporting.Groups(
+                        [reporting.Groups.REPOSITORY, reporting.Groups.OS_FACTS]
+                    ),
+                    reporting.Groups([reporting.Groups.INHIBITOR]),
+                    reporting.Remediation(
+                        hint=(
+                            "Examine the current state of the system's DB packages."
+                            "Complete the pending Governor install:\n"
+                            "  mysqlgovernor.py --mysql-version={governor}\n"
+                            "  mysqlgovernor.py --install --yes\n"
+                            "Or reset Governor to match the actual packages:\n"
+                            "  mysqlgovernor.py --mysql-version={rpm}\n"
+                            "  mysqlgovernor.py --install --yes\n"
+                            "Then restart the upgrade process.".format(
+                                governor=detected.governor_type, rpm=detected.pkg_type
+                            )
+                        )
+                    ),
+                ]
+            )
+            return
+
+        self.clmysql_type = detected.governor_type or detected.pkg_type
         if not self.clmysql_type:
             api.current_logger().warning("CL-MySQL type detection failed, skipping repository mapping")
             return

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from leapp.libraries.stdlib import CalledProcessError, api, run
 
@@ -20,9 +21,40 @@ MODULE_STREAMS = {
     "mariadb104": "mariadb:cl-MariaDB104",
     "mariadb105": "mariadb:cl-MariaDB105",
     "mariadb106": "mariadb:cl-MariaDB106",
+    "mariadb1011": "mariadb:cl-MariaDB1011",
     "mariadb1104": "mariadb:cl-MariaDB1104",
     "percona56": "percona:cl-Percona56",
 }
+
+
+def resolve_clmysql_module_stream(clmysql_type):
+    """
+    Return (dnf_module_name, stream) for CloudLinux Governor MySQL/MariaDB/Percona types.
+
+    Prefer MODULE_STREAMS; if missing, derive stream from the type string (e.g. mariadb1012 ->
+    mariadb:cl-MariaDB1012) so newer CL releases work before this table is updated.
+    """
+    if not clmysql_type:
+        return None, None
+
+    entry = MODULE_STREAMS.get(clmysql_type)
+    if entry:
+        mod_name, mod_stream = entry.split(":", 1)
+        return mod_name, mod_stream
+
+    match = re.match(r"^(mariadb)(\d+)$", clmysql_type)
+    if match:
+        return "mariadb", "cl-MariaDB{}".format(match.group(2))
+
+    match = re.match(r"^(mysql)(\d+)$", clmysql_type)
+    if match:
+        return "mysql", "cl-MySQL{}".format(match.group(2))
+
+    match = re.match(r"^(percona)(\d+)$", clmysql_type)
+    if match:
+        return "percona", "cl-Percona{}".format(match.group(2))
+
+    return None, None
 
 
 def get_clmysql_version_from_pkg():

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shutil
 
 from leapp.libraries.stdlib import CalledProcessError, api, run
 
@@ -57,25 +58,77 @@ def resolve_clmysql_module_stream(clmysql_type):
     return None, None
 
 
-def get_clmysql_version_from_pkg():
+def _resolve_mysqld_path():
     """
-    Detect the current installed CL-MySQL version.
+    Return absolute path to mysqld: PATH first, then usual daemon locations.
+    """
+    path = shutil.which("mysqld")
+    if path:
+        return path
+    for candidate in ("/usr/sbin/mysqld", "/usr/libexec/mysqld", "/usr/bin/mysqld"):
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
+def _clmysql_name_version_from_rpm(path):
+    """
+    Query the RPM that owns ``path`` and return (name_lower, version_lower) for the first
+    CloudLinux cl-{mariadb,mysql,percona} package when several packages claim the file.
     """
     try:
-        mysqld_safe_cmd = run(["which", "mysqld"])
+        rpm_out = run(
+            [
+                "rpm",
+                "-qf",
+                path,
+                "--queryformat",
+                "%{NAME} %{VERSION}\\n",
+            ]
+        )["stdout"]
     except CalledProcessError as err:
         api.current_logger().info(
-            "CL-MySQL version detection failed - unable to determine mysqld bin path: {}".format(str(err))
+            "Could not query RPM owner of mysqld path {0}: {1}".format(path, str(err))
         )
         return None
 
-    try:
-        rpm_qf_cmd = run(["rpm", "-qf", r'--qf="%{name} %{version}"', mysqld_safe_cmd["stdout"].strip()])
-    except CalledProcessError as err:
-        api.current_logger().info("Could not get CL-MySQL package version from RPM: {}".format(str(err)))
+    for line in rpm_out.strip().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            api.current_logger().info(
+                "Unexpected rpm --queryformat line for {0!r}: {1!r}".format(path, line)
+            )
+            continue
+        name, version = parts[0].lower(), parts[1].lower()
+        if "cl-mariadb" in name or "cl-mysql" in name or "cl-percona" in name:
+            return name, version
+
+    return None
+
+
+def get_clmysql_version_from_pkg():
+    """
+    Detect the current installed CL-MySQL/MariaDB/Percona version from the mysqld binary.
+    """
+    mysqld_path = _resolve_mysqld_path()
+    if not mysqld_path:
+        api.current_logger().info(
+            "CL-MySQL version detection failed: mysqld not found in PATH or standard locations"
+        )
         return None
 
-    name, version = rpm_qf_cmd["stdout"].lower().split(" ")
+    pair = _clmysql_name_version_from_rpm(mysqld_path)
+    if not pair:
+        api.current_logger().info(
+            "CL-MySQL version detection failed: no CloudLinux cl-mysql/cl-mariadb/cl-percona "
+            "package owns {0}".format(mysqld_path)
+        )
+        return None
+
+    name, version = pair
     if "cl-mariadb" in name:
         name = "mariadb"
     elif "cl-mysql" in name:
@@ -83,7 +136,6 @@ def get_clmysql_version_from_pkg():
     elif "cl-percona" in name:
         name = "percona"
     else:
-        # non-CL SQL package
         return None
 
     return "%s%s" % (name, "".join(version.split(".")[:2]))

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -1,8 +1,20 @@
+import collections
 import os
 import re
 import shutil
+from enum import Enum
 
 from leapp.libraries.stdlib import CalledProcessError, api, run
+
+
+class ClMysqlTypeStatus(Enum):
+    OK = "ok"
+    MISMATCH = "mismatch"
+
+
+ClMysqlTypeResult = collections.namedtuple(
+    "ClMysqlTypeResult", ["status", "governor_type", "pkg_type"]
+)
 
 # MySQL Governor tracks the DB type in two files:
 #   mysql.type           — the *desired* type set by --mysql-version (may be ahead of reality)
@@ -192,11 +204,33 @@ def get_clmysql_type():
 
     Prefer the MySQL Governor config file (authoritative when Governor manages the DB),
     fall back to detecting the type from the mysqld binary's RPM ownership.
+
+    When both sources are available, cross-check them. On mismatch, return a
+    result with :attr:`ClMysqlTypeStatus.MISMATCH` so the caller can raise an inhibitor.
+
+    :returns: :class:`ClMysqlTypeResult` with status, resolved type, and raw detection values.
     """
     governor_type = _get_clmysql_type_from_governor()
+    pkg_type = get_clmysql_version_from_pkg()
+
+    if governor_type and pkg_type and governor_type != pkg_type:
+        api.current_logger().warning(
+            "Governor mysql.type.installed says '{}' but RPM-based detection says '{}'."
+            .format(governor_type, pkg_type)
+        )
+        return ClMysqlTypeResult(
+            status=ClMysqlTypeStatus.MISMATCH,
+            governor_type=governor_type,
+            pkg_type=pkg_type,
+        )
+
     if governor_type:
         api.current_logger().debug(
             "CL-MySQL type from Governor file: {}".format(governor_type)
         )
-        return governor_type
-    return get_clmysql_version_from_pkg()
+
+    return ClMysqlTypeResult(
+        status=ClMysqlTypeStatus.OK,
+        governor_type=governor_type,
+        pkg_type=pkg_type,
+    )

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -4,8 +4,12 @@ import shutil
 
 from leapp.libraries.stdlib import CalledProcessError, api, run
 
-# This file contains the data on the currently active MySQL installation type and version.
-CL7_MYSQL_TYPE_FILE = "/usr/share/lve/dbgovernor/mysql.type"
+# MySQL Governor tracks the DB type in two files:
+#   mysql.type           — the *desired* type set by --mysql-version (may be ahead of reality)
+#   mysql.type.installed — the *actually installed* type, written after a successful --install
+# For Leapp we need what is really on disk, so we read mysql.type.installed.
+# Both files are present on CL7 and CL8+ when governor-mysql is installed.
+GOVERNOR_INSTALLED_TYPE_FILE = "/usr/share/lve/dbgovernor/mysql.type.installed"
 
 # This dict matches the MySQL type strings with DNF module and stream IDs.
 MODULE_STREAMS = {
@@ -145,21 +149,54 @@ def get_pkg_prefix(clmysql_type):
     """
     Get a Yum package prefix string from cl-mysql type.
     """
-    if "mysql" in clmysql_type:
+    if clmysql_type.startswith("mysql"):
         return "cl-MySQL"
-    elif "mariadb" in clmysql_type:
+    elif clmysql_type.startswith("mariadb"):
         return "cl-MariaDB"
-    elif "percona" in clmysql_type:
+    elif clmysql_type.startswith("percona"):
         return "cl-Percona"
     else:
         return None
 
 
+def _get_clmysql_type_from_governor():
+    """
+    Read the actually installed DB type from the MySQL Governor cache file.
+
+    Governor stores the desired type in `mysql.type` (written by `--mysql-version`)
+    and the actually installed type in `mysql.type.installed` (written after a
+    successful `--install`).  We read the installed file so that a pending
+    `--mysql-version` that was never followed by `--install` does not mislead Leapp.
+
+    Returns a type string like `mariadb106`, or None when Governor is absent,
+    the file is missing/empty, or the value is `auto`.
+    """
+    if not os.path.isfile(GOVERNOR_INSTALLED_TYPE_FILE):
+        return None
+    try:
+        with open(GOVERNOR_INSTALLED_TYPE_FILE, "r") as f:
+            value = f.read().strip()
+    except (IOError, OSError) as err:
+        api.current_logger().warning(
+            "Could not read Governor mysql.type.installed file: {}".format(err)
+        )
+        return None
+    if not value or value == "auto":
+        return None
+    return value
+
+
 def get_clmysql_type():
     """
-    Get the currently active MySQL type from the Governor configuration file.
+    Get the currently active CL MySQL/MariaDB/Percona type.
+
+    Prefer the MySQL Governor config file (authoritative when Governor manages the DB),
+    fall back to detecting the type from the mysqld binary's RPM ownership.
     """
-    # if os.path.isfile(CL7_MYSQL_TYPE_FILE):
-    #     with open(CL7_MYSQL_TYPE_FILE, "r") as mysql_f:
-    #         return mysql_f.read()
+    governor_type = _get_clmysql_type_from_governor()
+    if governor_type:
+        api.current_logger().debug(
+            "CL-MySQL type from Governor file: {}".format(governor_type)
+        )
+        return governor_type
     return get_clmysql_version_from_pkg()

--- a/repos/system_upgrade/cloudlinux/libraries/tests/test_clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/tests/test_clmysql.py
@@ -1,0 +1,260 @@
+import os
+
+import pytest
+
+from leapp.libraries.common.clmysql import (
+    ClMysqlTypeStatus,
+    _clmysql_name_version_from_rpm,
+    _get_clmysql_type_from_governor,
+    _resolve_mysqld_path,
+    get_clmysql_type,
+    get_pkg_prefix,
+    resolve_clmysql_module_stream,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_clmysql_module_stream
+# ---------------------------------------------------------------------------
+
+class TestResolveClmysqlModuleStream(object):
+    """Test explicit MODULE_STREAMS lookup and regex fallback."""
+
+    @pytest.mark.parametrize(
+        "clmysql_type,expected",
+        [
+            # Explicit MODULE_STREAMS entries
+            ("mysql55", ("mysql", "cl-MySQL55")),
+            ("mysql80", ("mysql", "cl-MySQL80")),
+            ("mariadb103", ("mariadb", "cl-MariaDB103")),
+            ("mariadb1011", ("mariadb", "cl-MariaDB1011")),
+            ("mariadb1104", ("mariadb", "cl-MariaDB1104")),
+            ("percona56", ("percona", "cl-Percona56")),
+        ],
+    )
+    def test_known_streams(self, clmysql_type, expected):
+        assert resolve_clmysql_module_stream(clmysql_type) == expected
+
+    @pytest.mark.parametrize(
+        "clmysql_type,expected",
+        [
+            # Future versions not in MODULE_STREAMS -- regex fallback
+            ("mariadb1012", ("mariadb", "cl-MariaDB1012")),
+            ("mysql90", ("mysql", "cl-MySQL90")),
+            ("percona84", ("percona", "cl-Percona84")),
+        ],
+    )
+    def test_fallback_derivation(self, clmysql_type, expected):
+        assert resolve_clmysql_module_stream(clmysql_type) == expected
+
+    @pytest.mark.parametrize(
+        "clmysql_type",
+        [
+            None,
+            "",
+            "postgres15",
+            "unknown",
+            "maria-db103",   # hyphen breaks the pattern
+        ],
+    )
+    def test_unresolvable(self, clmysql_type):
+        assert resolve_clmysql_module_stream(clmysql_type) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_mysqld_path
+# ---------------------------------------------------------------------------
+
+class TestResolveMysqldPath(object):
+
+    def test_found_via_which(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/mysqld")
+        assert _resolve_mysqld_path() == "/usr/bin/mysqld"
+
+    def test_fallback_to_standard_location(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        # Only /usr/libexec/mysqld "exists"
+        monkeypatch.setattr(
+            "os.path.isfile",
+            lambda p: p == "/usr/libexec/mysqld",
+        )
+        assert _resolve_mysqld_path() == "/usr/libexec/mysqld"
+
+    def test_not_found(self, monkeypatch):
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        monkeypatch.setattr("os.path.isfile", lambda _p: False)
+        assert _resolve_mysqld_path() is None
+
+
+# ---------------------------------------------------------------------------
+# _clmysql_name_version_from_rpm
+# ---------------------------------------------------------------------------
+
+class TestClmysqlNameVersionFromRpm(object):
+
+    def _mock_run(self, stdout):
+        """Return a ``run`` replacement that yields *stdout*."""
+        def fake_run(cmd):
+            return {"stdout": stdout}
+        return fake_run
+
+    def test_single_cl_package(self, monkeypatch):
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.run",
+            self._mock_run("cl-MariaDB1011-server 10.11.6\n"),
+        )
+        assert _clmysql_name_version_from_rpm("/usr/sbin/mysqld") == (
+            "cl-mariadb1011-server",
+            "10.11.6",
+        )
+
+    def test_multiple_packages_picks_cl(self, monkeypatch):
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.run",
+            self._mock_run(
+                "some-other-pkg 1.0\n"
+                "cl-MySQL80-server 8.0.35\n"
+            ),
+        )
+        assert _clmysql_name_version_from_rpm("/usr/sbin/mysqld") == (
+            "cl-mysql80-server",
+            "8.0.35",
+        )
+
+    def test_no_cl_package(self, monkeypatch):
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.run",
+            self._mock_run("mariadb-server 10.5.22\n"),
+        )
+        assert _clmysql_name_version_from_rpm("/usr/sbin/mysqld") is None
+
+    def test_rpm_command_fails(self, monkeypatch):
+        from leapp.libraries.stdlib import CalledProcessError
+
+        def failing_run(cmd):
+            raise CalledProcessError("rpm failed", cmd, {})
+
+        monkeypatch.setattr("leapp.libraries.common.clmysql.run", failing_run)
+        assert _clmysql_name_version_from_rpm("/usr/sbin/mysqld") is None
+
+
+# ---------------------------------------------------------------------------
+# _get_clmysql_type_from_governor
+# ---------------------------------------------------------------------------
+
+class TestGetClmysqlTypeFromGovernor(object):
+
+    def test_file_present(self, monkeypatch, tmpdir):
+        f = tmpdir.join("mysql.type")
+        f.write("mariadb106")
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE", str(f)
+        )
+        assert _get_clmysql_type_from_governor() == "mariadb106"
+
+    def test_file_with_whitespace(self, monkeypatch, tmpdir):
+        f = tmpdir.join("mysql.type")
+        f.write("  mysql80\n")
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE", str(f)
+        )
+        assert _get_clmysql_type_from_governor() == "mysql80"
+
+    def test_file_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE",
+            "/nonexistent/path/mysql.type",
+        )
+        assert _get_clmysql_type_from_governor() is None
+
+    def test_file_empty(self, monkeypatch, tmpdir):
+        f = tmpdir.join("mysql.type.installed")
+        f.write("")
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE", str(f)
+        )
+        assert _get_clmysql_type_from_governor() is None
+
+    def test_auto_value_ignored(self, monkeypatch, tmpdir):
+        f = tmpdir.join("mysql.type.installed")
+        f.write("auto")
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE", str(f)
+        )
+        assert _get_clmysql_type_from_governor() is None
+
+
+# ---------------------------------------------------------------------------
+# get_pkg_prefix
+# ---------------------------------------------------------------------------
+
+class TestGetPkgPrefix(object):
+
+    @pytest.mark.parametrize(
+        "clmysql_type,expected",
+        [
+            ("mysql80", "cl-MySQL"),
+            ("mysql55", "cl-MySQL"),
+            ("mariadb106", "cl-MariaDB"),
+            ("mariadb1011", "cl-MariaDB"),
+            ("percona56", "cl-Percona"),
+        ],
+    )
+    def test_known_types(self, clmysql_type, expected):
+        assert get_pkg_prefix(clmysql_type) == expected
+
+    def test_unknown_type(self):
+        assert get_pkg_prefix("postgres15") is None
+
+
+# ---------------------------------------------------------------------------
+# get_clmysql_type  (integration of governor + RPM detection)
+# ---------------------------------------------------------------------------
+
+class TestGetClmysqlType(object):
+
+    def _patch_sources(self, monkeypatch, governor_ret, pkg_ret):
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql._get_clmysql_type_from_governor",
+            lambda: governor_ret,
+        )
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.get_clmysql_version_from_pkg",
+            lambda: pkg_ret,
+        )
+
+    def test_governor_preferred(self, monkeypatch):
+        self._patch_sources(monkeypatch, "mariadb106", "mariadb106")
+        result = get_clmysql_type()
+        assert result.status == ClMysqlTypeStatus.OK
+        assert result.governor_type == "mariadb106"
+        assert result.pkg_type == "mariadb106"
+
+    def test_fallback_to_rpm(self, monkeypatch):
+        self._patch_sources(monkeypatch, None, "mysql80")
+        result = get_clmysql_type()
+        assert result.status == ClMysqlTypeStatus.OK
+        assert result.governor_type is None
+        assert result.pkg_type == "mysql80"
+
+    def test_both_none(self, monkeypatch):
+        self._patch_sources(monkeypatch, None, None)
+        result = get_clmysql_type()
+        assert result.status == ClMysqlTypeStatus.OK
+        assert result.governor_type is None
+        assert result.pkg_type is None
+
+    def test_mismatch(self, monkeypatch):
+        self._patch_sources(monkeypatch, "mariadb1011", "mariadb106")
+        result = get_clmysql_type()
+        assert result.status == ClMysqlTypeStatus.MISMATCH
+        assert result.governor_type == "mariadb1011"
+        assert result.pkg_type == "mariadb106"
+
+    def test_governor_only(self, monkeypatch):
+        """Governor file present but mysqld not found (no RPM detection)."""
+        self._patch_sources(monkeypatch, "percona56", None)
+        result = get_clmysql_type()
+        assert result.status == ClMysqlTypeStatus.OK
+        assert result.governor_type == "percona56"
+        assert result.pkg_type is None


### PR DESCRIPTION
Not precisely related to the exact case described in the mentioned Jira task, but was noticed during work on it.

An existing version of cl-MariaDB was not present in the module streams, and would get skipped as a result.

In addition, overall CL DB detection wasn't particularly robust, and could use some improvements.
The correct module to enable could be derived from DB version, since they follow the same scheme.

Also, we can leverage Governor config files to compare them to the actual state of RPMs on the system. A discrepancy means it's dangerous to proceed with the upgrade - if Governor and the system disagree on what's supposed to be installed, we cannot trust that the needed package repos are configured and available.