### PR TITLE
Fix Python 2.7 SyntaxError from non-ASCII symbols in clmysql.py

### DIFF
--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -17,8 +17,8 @@ ClMysqlTypeResult = collections.namedtuple(
 )
 
 # MySQL Governor tracks the DB type in two files:
-#   mysql.type           — the *desired* type set by --mysql-version (may be ahead of reality)
-#   mysql.type.installed — the *actually installed* type, written after a successful --install
+#   mysql.type           - the *desired* type set by --mysql-version (may be ahead of reality)
+#   mysql.type.installed - the *actually installed* type, written after a successful --install
 # For Leapp we need what is really on disk, so we read mysql.type.installed.
 # Both files are present on CL7 and CL8+ when governor-mysql is installed.
 GOVERNOR_INSTALLED_TYPE_FILE = "/usr/share/lve/dbgovernor/mysql.type.installed"


### PR DESCRIPTION
Python 2.7 on CL7 rejects non-ASCII bytes without an encoding declaration, causing leapp to fail when loading the clmysqlrepositorysetup actor.