### PR TITLE
CLOS-4259: Add check for cl-mysql-meta URL correctness and reorganize clmysql repository setup actor

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_cloudlinux.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_cloudlinux.py
@@ -92,7 +92,7 @@ def clmysql_process(lib, repofile_name, repofile_data):
     expected_fragment = get_expected_repo_url_fragment(lib.clmysql_type)
     if expected_fragment:
         for repo_data in repofile_data.data:
-            if repo_data.repoid == "cl-mysql-meta" and expected_fragment not in repo_data.baseurl:
+            if repo_data.repoid == "cl-mysql-meta" and "/{}/".format(expected_fragment) not in repo_data.baseurl:
                 api.current_logger().warning(
                     "cl-mysql-meta repo baseurl '{}' does not match detected DB type '{}' "
                     "(expected '{}' in URL)."
@@ -126,8 +126,8 @@ def clmysql_process(lib, repofile_name, repofile_data):
                         reporting.Remediation(
                             hint=(
                                 "Re-run MySQL Governor to regenerate the repository file: "
-                                "mysqlgovernor.py --install --yes,"
-                                "then restart the upgrade process."
+                                "mysqlgovernor.py --install --yes, "
+                                "then restart the upgrade process. "
                                 "Alternatively, if the repository file was manually edited, "
                                 "either correct the baseurl to match the installed DB type or "
                                 "set the desired DB type in Governor and re-run --install "

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_cloudlinux.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_cloudlinux.py
@@ -1,0 +1,210 @@
+"""
+Handler for CloudLinux Governor-managed MySQL/MariaDB/Percona repositories.
+"""
+import copy
+
+from leapp import reporting
+from leapp.libraries.common.cl_repofileutils import create_leapp_repofile_copy
+from leapp.libraries.common.clmysql import (
+    ClMysqlTypeStatus,
+    construct_repomap_data,
+    get_clmysql_type,
+    get_expected_repo_url_fragment,
+)
+from leapp.libraries.common.config.version import get_target_major_version
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    CustomTargetRepository,
+    CustomTargetRepositoryFile,
+    RepositoryFile,
+)
+
+OLD_CLMYSQL_VERSIONS = ["5.0", "5.1"]
+
+
+def clmysql_process(lib, repofile_name, repofile_data):
+    """
+    Process CL-provided MySQL options.
+
+    :param lib: :class:`MySqlRepositorySetupLibrary` instance (shared state).
+    :param repofile_name: repository file name without ``.repo`` suffix.
+    :param repofile_data: parsed :class:`RepositoryFile`.
+    """
+    detected = get_clmysql_type()
+
+    if detected.status == ClMysqlTypeStatus.MISMATCH:
+        reporting.create_report(
+            [
+                reporting.Title(
+                    "Mismatch between Governor DB type and installed packages"
+                ),
+                reporting.Summary(
+                    "MySQL Governor records the installed database type as '{governor}', "
+                    "but the mysqld binary on disk belongs to '{rpm}'. "
+                    "This usually means 'mysqlgovernor.py --mysql-version' was run "
+                    "without a follow-up '--install', or packages were changed manually. "
+                    "Proceeding could enable the wrong DNF module stream and break the upgrade.".format(
+                        governor=detected.governor_type, rpm=detected.pkg_type
+                    )
+                ),
+                reporting.Severity(reporting.Severity.HIGH),
+                reporting.Groups(
+                    [reporting.Groups.REPOSITORY, reporting.Groups.OS_FACTS]
+                ),
+                reporting.Groups([reporting.Groups.INHIBITOR]),
+                reporting.Remediation(
+                    hint=(
+                        "Examine the current state of the system's DB packages."
+                        "Complete the pending Governor install:\n"
+                        "  mysqlgovernor.py --mysql-version={governor}\n"
+                        "  mysqlgovernor.py --install --yes\n"
+                        "Or reset Governor to match the actual packages:\n"
+                        "  mysqlgovernor.py --mysql-version={rpm}\n"
+                        "  mysqlgovernor.py --install --yes\n"
+                        "Then restart the upgrade process.".format(
+                            governor=detected.governor_type, rpm=detected.pkg_type
+                        )
+                    )
+                ),
+            ]
+        )
+        return
+
+    lib.clmysql_type = detected.governor_type or detected.pkg_type
+    if not lib.clmysql_type:
+        api.current_logger().warning("CL-MySQL type detection failed, skipping repository mapping")
+        return
+    api.current_logger().debug("Detected CL-MySQL type: {}".format(lib.clmysql_type))
+
+    data_to_log = [
+        (repo_data.repoid, "enabled" if repo_data.enabled else "disabled") for repo_data in repofile_data.data
+    ]
+
+    api.current_logger().debug("repoids from CloudLinux repofile {}: {}".format(repofile_name, data_to_log))
+
+    # Validate that cl-mysql-meta repo's baseurl matches the detected DB type.
+    # Governor configures the URL based on the selected DB version (e.g. cl-mariadb-10.6 for mariadb106).
+    # If the user switched DB versions without re-running Governor --install,
+    # the repo may point to the wrong package set.
+    # We inhibit rather than auto-correct because Governor is the authoritative source
+    # for this repo file and has the real download-and-write logic;
+    # re-running --install is the proper fix.
+    expected_fragment = get_expected_repo_url_fragment(lib.clmysql_type)
+    if expected_fragment:
+        for repo_data in repofile_data.data:
+            if repo_data.repoid == "cl-mysql-meta" and expected_fragment not in repo_data.baseurl:
+                api.current_logger().warning(
+                    "cl-mysql-meta repo baseurl '{}' does not match detected DB type '{}' "
+                    "(expected '{}' in URL)."
+                    .format(repo_data.baseurl, lib.clmysql_type, expected_fragment)
+                )
+                reporting.create_report(
+                    [
+                        reporting.Title(
+                            "cl-mysql.repo does not match the installed database type"
+                        ),
+                        reporting.Summary(
+                            "The cl-mysql-meta repository is configured for a different "
+                            "database type than what is actually installed. "
+                            "The detected database type is '{}', but the cl-mysql-meta "
+                            "repo URL points to '{}'. "
+                            "This may happen when the database version was changed "
+                            "without a follow-up 'mysqlgovernor.py --install', or the "
+                            "cl-mysql.repo file was manually edited. "
+                            "Proceeding with the wrong repository would result in "
+                            "an incorrect upgrade operation."
+                            .format(lib.clmysql_type, repo_data.baseurl)
+                        ),
+                        reporting.Severity(reporting.Severity.HIGH),
+                        reporting.Groups(
+                            [
+                                reporting.Groups.REPOSITORY,
+                                reporting.Groups.OS_FACTS
+                            ]
+                        ),
+                        reporting.Groups([reporting.Groups.INHIBITOR]),
+                        reporting.Remediation(
+                            hint=(
+                                "Re-run MySQL Governor to regenerate the repository file: "
+                                "mysqlgovernor.py --install --yes,"
+                                "then restart the upgrade process."
+                                "Alternatively, if the repository file was manually edited, "
+                                "either correct the baseurl to match the installed DB type or "
+                                "set the desired DB type in Governor and re-run --install "
+                                "to have it write the correct URL."
+                            )
+                        ),
+                    ]
+                )
+                return
+
+    cl_target_repofile_list = []
+    target_major = get_target_major_version()
+
+    for source_repo in repofile_data.data:
+        # cl-mysql URLs look like this:
+        # baseurl=http://repo.cloudlinux.com/other/cl$releasever/mysqlmeta/cl-mariadb-10.3/$basearch/
+        # We don't want any duplicate repoid entries - they'd cause yum/dnf to fail.
+        # Make everything unique by adding -<target_major> to the repoid.
+        target_repo = copy.deepcopy(source_repo)
+        target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
+        # releasever may be something like 8.6, while only 8 is acceptable.
+        target_repo.baseurl = target_repo.baseurl.replace("/cl$releasever/", "/cl{}/".format(target_major))
+
+        # Old CL MySQL versions (5.0 and 5.1) won't be available in CL8+.
+        if any(ver in target_repo.baseurl for ver in OLD_CLMYSQL_VERSIONS):
+            reporting.create_report(
+                [
+                    reporting.Title("An old CL-MySQL version will no longer be available in EL{}".format(target_major)),
+                    reporting.Summary(
+                        "An old CloudLinux-provided MySQL version is installed on this system. "
+                        "It will no longer be available on the target system. "
+                        "This situation cannot be automatically resolved by Leapp. "
+                        "Problematic repository: {0}".format(target_repo.repoid)
+                    ),
+                    reporting.Severity(reporting.Severity.MEDIUM),
+                    reporting.Groups([reporting.Groups.REPOSITORY]),
+                    reporting.Groups([reporting.Groups.INHIBITOR]),
+                    reporting.Remediation(
+                        hint=(
+                            "Upgrade to a more recent MySQL version, or "
+                            "uninstall the deprecated MySQL packages and disable the repository. "
+                            "Note that you will also need to update any bindings (e.g., PHP or Python) "
+                            "that are dependent on this MySQL version."
+                        )
+                    ),
+                ]
+            )
+
+        # Governor-managed MySQL/MariaDB repos may all be disabled, but we still
+        # need them enabled for the target system so DNF can upgrade the packages.
+        # Force-enable both cl-mysql-meta and mysqclient target repos.
+        if target_repo.enabled or target_repo.repoid in (
+            "mysqclient-{}".format(target_major),
+            "cl-mysql-meta-{}".format(target_major),
+        ):
+            api.current_logger().debug("Generating custom cl-mysql repo: {}".format(target_repo.repoid))
+            lib.custom_repo_msgs.append(
+                CustomTargetRepository(
+                    repoid=target_repo.repoid,
+                    name=target_repo.name,
+                    baseurl=target_repo.baseurl,
+                    enabled=True,
+                )
+            )
+            lib.mapping_msgs.append(
+                construct_repomap_data(source_repo.repoid, target_repo.repoid)
+            )
+            # Gather the enabled repositories for the new repofile.
+            # They'll be used to create a new custom repofile for the target userspace.
+            cl_target_repofile_list.append(target_repo)
+
+    # Always register the cloudlinux type when CL MySQL/MariaDB is detected.
+    # Even if all repos in cl-mysql.repo are disabled (can happen with Governor),
+    # we still need the target repos for packages like mysqlclient that were
+    # installed from local RPMs and have no repo association.
+    lib.mysql_types.add("cloudlinux")
+    # Provide the object with the modified repository data to the target userspace.
+    cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
+    leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
+    api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_upstream_mariadb.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_upstream_mariadb.py
@@ -1,0 +1,120 @@
+"""
+Handler for upstream (mariadb.org) MariaDB repositories.
+"""
+import copy
+
+from leapp import reporting
+from leapp.libraries.common.cl_repofileutils import create_leapp_repofile_copy
+from leapp.libraries.common.clmysql import construct_repomap_data
+from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    CustomTargetRepository,
+    CustomTargetRepositoryFile,
+    RepositoryFile,
+)
+
+OLD_MARIADB_UPSTREAM_VERSIONS_CL8 = ["10.3", "10.4"]
+
+
+def _make_upgrade_mariadb_url(mariadb_url, source_major, target_major):
+    """
+    Rewrite an upstream MariaDB repo URL for the target OS version.
+
+    Maria URLs look like this::
+
+        baseurl = https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64
+        baseurl = https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/
+        baseurl = https://distrohub.kyiv.ua/mariadb/yum/11.8/rhel/$releasever/$basearch
+        baseurl = https://mariadb.gb.ssimn.org/yum/12.0/centos/$releasever/$basearch
+        baseurl = https://mariadb.gb.ssimn.org/yum/12.0/almalinux8-amd64/$releasever/$basearch
+
+    We replace the parts of the URL to make them work with the target OS version.
+    """
+    if not mariadb_url:
+        return None
+    # Replace the first occurrence of source_major with target_major after 'yum'
+    url_parts = mariadb_url.split("yum", 1)
+    if len(url_parts) == 2 and url_parts[1]:
+        # Replace major version in "/centos/7/" and /12.0/almalinux9-amd64/,
+        # but do not replace it in /mariadb-10.7/yum/
+        url_parts[1] = url_parts[1].replace("/{}/".format(source_major), "/{}/".format(target_major))
+        url_parts[1] = url_parts[1].replace("{}-".format(source_major), "{}-".format(target_major))
+        # Replace $releasever because upstream repos expect major version
+        # and cloudlinux provides major.minor as $releasever
+        url_parts[1] = url_parts[1].replace('$releasever', str(target_major))
+        return "yum".join(url_parts)
+    else:
+        api.current_logger().warning("Unsupported repository URL={}, skipping".format(mariadb_url))
+        return
+
+
+def mariadb_process(lib, repofile_name, repofile_data):
+    """
+    Process upstream MariaDB options.
+
+    Versions of MariaDB installed from https://mariadb.org/.
+
+    :param lib: :class:`MySqlRepositorySetupLibrary` instance (shared state).
+    :param repofile_name: repository file name without ``.repo`` suffix.
+    :param repofile_data: parsed :class:`RepositoryFile`.
+    """
+
+    cl_target_repofile_list = []
+    target_major = get_target_major_version()
+    source_major = get_source_major_version()
+
+    for source_repo in repofile_data.data:
+        target_repo = copy.deepcopy(source_repo)
+        target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
+        target_repo.baseurl = _make_upgrade_mariadb_url(source_repo.baseurl, source_major, target_major)
+
+        if target_repo.enabled:
+            # MariaDB 10.4 is not compatible with Leapp upgrade
+            if str(source_major) == "8" and any(ver in target_repo.baseurl for ver in OLD_MARIADB_UPSTREAM_VERSIONS_CL8):
+                reporting.create_report(
+                    [
+                        reporting.Title("MariaDB version is not compatible with Leapp upgrade"),
+                        reporting.Summary(
+                            "MariaDB is installed on this system but its version is not compatible with Leapp upgrade process. "
+                            "The upgrade is blocked to prevent system instability. "
+                            "This situation cannot be automatically resolved by Leapp. "
+                            "Problematic repository: {0}".format(target_repo.repoid)
+                        ),
+                        reporting.Severity(reporting.Severity.MEDIUM),
+                        reporting.Groups([reporting.Groups.REPOSITORY]),
+                        reporting.Groups([reporting.Groups.INHIBITOR]),
+                        reporting.Remediation(
+                            hint=(
+                                "Upgrade to a more recent MariaDB version, or "
+                                "uninstall the MariaDB packages and disable the repository. "
+                                "Note that you will also need to update any bindings (e.g., PHP or Python) "
+                                "that are dependent on this MariaDB version."
+                            )
+                        ),
+                    ]
+                )
+
+            api.current_logger().debug("Generating custom MariaDB repo: {}".format(target_repo.repoid))
+            lib.custom_repo_msgs.append(
+                CustomTargetRepository(
+                    repoid=target_repo.repoid,
+                    name=target_repo.name,
+                    baseurl=target_repo.baseurl,
+                    enabled=target_repo.enabled,
+                )
+            )
+            lib.mapping_msgs.append(
+                construct_repomap_data(source_repo.repoid, target_repo.repoid)
+            )
+            cl_target_repofile_list.append(target_repo)
+
+    if any(repo.enabled for repo in repofile_data.data):
+        # Since MariaDB URLs have major versions written in, we need a new repo file
+        # to feed to the target userspace.
+        lib.mysql_types.add("mariadb")
+        cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
+        leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
+        api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
+    else:
+        api.current_logger().debug("No repos from MariaDB repofile {} enabled, ignoring".format(repofile_name))

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_upstream_mysql.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysql_upstream_mysql.py
@@ -1,0 +1,103 @@
+"""
+Handler for upstream (mysql.com) MySQL Community repositories.
+"""
+import copy
+
+from leapp import reporting
+from leapp.libraries.common.cl_repofileutils import create_leapp_repofile_copy
+from leapp.libraries.common.clmysql import construct_repomap_data
+from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
+from leapp.libraries.stdlib import api
+from leapp.models import (
+    CustomTargetRepository,
+    CustomTargetRepositoryFile,
+    RepositoryFile,
+)
+
+OLD_MYSQL_UPSTREAM_VERSIONS_CL7 = ["5.7", "5.6", "5.5"]
+OLD_MYSQL_UPSTREAM_VERSIONS_CL8 = ["5.7", "5.6"]
+
+
+def mysql_process(lib, repofile_name, repofile_data):
+    """
+    Process upstream MySQL options.
+
+    Versions of MySQL installed from https://mysql.com/.
+
+    :param lib: :class:`MySqlRepositorySetupLibrary` instance (shared state).
+    :param repofile_name: repository file name without ``.repo`` suffix.
+    :param repofile_data: parsed :class:`RepositoryFile`.
+    """
+
+    cl_target_repofile_list = []
+    target_major = get_target_major_version()
+    source_major = get_source_major_version()
+
+    # Select the correct list of old MySQL versions for the source major version
+    if str(source_major) == "7":
+        old_mysql_versions = OLD_MYSQL_UPSTREAM_VERSIONS_CL7
+    else:
+        old_mysql_versions = OLD_MYSQL_UPSTREAM_VERSIONS_CL8
+
+    for source_repo in repofile_data.data:
+        # URLs look like this:
+        # baseurl = https://repo.mysql.com/yum/mysql-8.0-community/el/7/x86_64/
+        # Remember that we always want to modify names, to avoid "duplicate repository" errors.
+        target_repo = copy.deepcopy(source_repo)
+        target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
+        # Replace /el/<source_major>/ with /el/<target_major>/
+        target_repo.baseurl = target_repo.baseurl.replace("/el/{}/".format(source_major), "/el/{}/".format(target_major))
+        # releasever may be something like 8.6, while only 8 is acceptable.
+        target_repo.baseurl = target_repo.baseurl.replace("/$releasever/", "/{}/".format(target_major))
+
+        if target_repo.enabled:
+            # MySQL package repos don't have these versions available for EL8 anymore.
+            # There's only 8.0 available.
+            # There'll be nothing to upgrade to.
+            # CL repositories do provide them, though.
+            if any(ver in target_repo.name for ver in old_mysql_versions):
+                reporting.create_report(
+                    [
+                        reporting.Title("An old MySQL version will no longer be available in EL{}".format(target_major)),
+                        reporting.Summary(
+                            "A yum repository for an old MySQL version is enabled on this system. "
+                            "It will no longer be available on the target system. "
+                            "This situation cannot be automatically resolved by Leapp. "
+                            "Problematic repository: {0}".format(target_repo.repoid)
+                        ),
+                        reporting.Severity(reporting.Severity.MEDIUM),
+                        reporting.Groups([reporting.Groups.REPOSITORY]),
+                        reporting.Groups([reporting.Groups.INHIBITOR]),
+                        reporting.Remediation(
+                            hint=(
+                                "Upgrade to a more recent MySQL version, "
+                                "uninstall the deprecated MySQL packages and disable the repository, "
+                                "or switch to CloudLinux MySQL Governor-provided version of MySQL to "
+                                "continue using the old MySQL version."
+                            )
+                        ),
+                    ]
+                )
+            api.current_logger().debug("Generating custom MySQL repo: {}".format(target_repo.repoid))
+            lib.custom_repo_msgs.append(
+                CustomTargetRepository(
+                    repoid=target_repo.repoid,
+                    name=target_repo.name,
+                    baseurl=target_repo.baseurl,
+                    enabled=target_repo.enabled,
+                )
+            )
+            lib.mapping_msgs.append(
+                construct_repomap_data(source_repo.repoid, target_repo.repoid)
+            )
+            cl_target_repofile_list.append(target_repo)
+
+    if any(repo.enabled for repo in repofile_data.data):
+        # MySQL typically has multiple repo files, so we want to make sure we're
+        # adding the type to list only once.
+        lib.mysql_types.add("mysql")
+        cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
+        leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
+        api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
+    else:
+        api.current_logger().debug("No repos from MySQL repofile {} enabled, ignoring".format(repofile_name))

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/libraries/clmysqlrepositorysetup.py
@@ -1,4 +1,11 @@
-import copy
+"""
+Coordinator for MySQL/MariaDB repository setup during CloudLinux ELevate upgrades.
+
+Delegates repo-specific logic to handler modules:
+  - clmysql_cloudlinux:       Governor-managed CL MySQL/MariaDB/Percona
+  - clmysql_upstream_mariadb: upstream mariadb.org repositories
+  - clmysql_upstream_mysql:   upstream mysql.com repositories
+"""
 import os
 
 from leapp import reporting
@@ -7,37 +14,28 @@ from leapp.libraries.common.cl_repofileutils import (
     LEAPP_COPY_SUFFIX,
     REPO_DIR,
     REPOFILE_SUFFIX,
-    create_leapp_repofile_copy,
 )
 from leapp.libraries.common.clmysql import (
-    ClMysqlTypeStatus,
     MODULE_STREAMS,
-    get_clmysql_type,
+    construct_repomap_data,
     get_pkg_prefix,
     resolve_clmysql_module_stream,
 )
-from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.stdlib import api
 from leapp.models import (
-    CustomTargetRepository,
-    CustomTargetRepositoryFile,
     InstalledMySqlTypes,
     InstalledRPM,
     Module,
-    PESIDRepositoryEntry,
-    RepoMapEntry,
-    RepositoriesMapping,
-    RepositoryFile,
     RpmTransactionTasks,
 )
+
+from leapp.libraries.actor.clmysql_cloudlinux import clmysql_process
+from leapp.libraries.actor.clmysql_upstream_mariadb import mariadb_process
+from leapp.libraries.actor.clmysql_upstream_mysql import mysql_process
 
 CL_MARKERS = ["cl-mysql", "cl-mariadb", "cl-percona"]
 MARIA_MARKERS = ["MariaDB"]
 MYSQL_MARKERS = ["mysql-community"]
-OLD_CLMYSQL_VERSIONS = ["5.0", "5.1"]
-OLD_MYSQL_UPSTREAM_VERSIONS_CL7 = ["5.7", "5.6", "5.5"]
-OLD_MYSQL_UPSTREAM_VERSIONS_CL8 = ["5.7", "5.6"]  # adjust as needed for CL8
-OLD_MARIADB_UPSTREAM_VERSIONS_CL8 = ["10.3", "10.4"]  # MariaDB versions to block for CL8 source
 
 
 def build_install_list(prefix):
@@ -58,36 +56,6 @@ def build_install_list(prefix):
     return to_upgrade
 
 
-def make_pesid_repo(pesid, major_version, repoid, arch='x86_64', repo_type='rpm', channel='ga', rhui=''):
-    """
-    PESIDRepositoryEntry factory function allowing shorter data description by providing default values.
-    """
-    return PESIDRepositoryEntry(
-        pesid=pesid,
-        major_version=major_version,
-        repoid=repoid,
-        arch=arch,
-        repo_type=repo_type,
-        channel=channel,
-        rhui=rhui
-    )
-
-
-def construct_repomap_data(source_id, target_id):
-    """
-    Construct the repository mapping data.
-    """
-    source_major = get_source_major_version()
-    target_major = get_target_major_version()
-    return RepositoriesMapping(
-        mapping=[RepoMapEntry(source=source_id, target=[target_id])],
-        repositories=[
-            make_pesid_repo(source_id, source_major, source_id),
-            make_pesid_repo(target_id, target_major, target_id)
-        ]
-    )
-
-
 class MySqlRepositorySetupLibrary(object):
     """
     Detect the various MySQL/MariaDB variants that may be installed on the system
@@ -102,304 +70,6 @@ class MySqlRepositorySetupLibrary(object):
         # Messages to send about custom generated package repositories.
         self.custom_repo_msgs = []
         self.mapping_msgs = []
-
-    def clmysql_process(self, repofile_name, repofile_data):
-        """
-        Process CL-provided MySQL options.
-        """
-        detected = get_clmysql_type()
-
-        if detected.status == ClMysqlTypeStatus.MISMATCH:
-            reporting.create_report(
-                [
-                    reporting.Title(
-                        "Mismatch between Governor DB type and installed packages"
-                    ),
-                    reporting.Summary(
-                        "MySQL Governor records the installed database type as '{governor}', "
-                        "but the mysqld binary on disk belongs to '{rpm}'. "
-                        "This usually means 'mysqlgovernor.py --mysql-version' was run "
-                        "without a follow-up '--install', or packages were changed manually. "
-                        "Proceeding could enable the wrong DNF module stream and break the upgrade.".format(
-                            governor=detected.governor_type, rpm=detected.pkg_type
-                        )
-                    ),
-                    reporting.Severity(reporting.Severity.HIGH),
-                    reporting.Groups(
-                        [reporting.Groups.REPOSITORY, reporting.Groups.OS_FACTS]
-                    ),
-                    reporting.Groups([reporting.Groups.INHIBITOR]),
-                    reporting.Remediation(
-                        hint=(
-                            "Examine the current state of the system's DB packages."
-                            "Complete the pending Governor install:\n"
-                            "  mysqlgovernor.py --mysql-version={governor}\n"
-                            "  mysqlgovernor.py --install --yes\n"
-                            "Or reset Governor to match the actual packages:\n"
-                            "  mysqlgovernor.py --mysql-version={rpm}\n"
-                            "  mysqlgovernor.py --install --yes\n"
-                            "Then restart the upgrade process.".format(
-                                governor=detected.governor_type, rpm=detected.pkg_type
-                            )
-                        )
-                    ),
-                ]
-            )
-            return
-
-        self.clmysql_type = detected.governor_type or detected.pkg_type
-        if not self.clmysql_type:
-            api.current_logger().warning("CL-MySQL type detection failed, skipping repository mapping")
-            return
-        api.current_logger().debug("Detected CL-MySQL type: {}".format(self.clmysql_type))
-
-        data_to_log = [
-            (repo_data.repoid, "enabled" if repo_data.enabled else "disabled") for repo_data in repofile_data.data
-        ]
-
-        api.current_logger().debug("repoids from CloudLinux repofile {}: {}".format(repofile_name, data_to_log))
-
-        cl_target_repofile_list = []
-        target_major = get_target_major_version()
-
-        # Were any repositories enabled?
-        for source_repo in repofile_data.data:
-            # cl-mysql URLs look like this:
-            # baseurl=http://repo.cloudlinux.com/other/cl$releasever/mysqlmeta/cl-mariadb-10.3/$basearch/
-            # We don't want any duplicate repoid entries - they'd cause yum/dnf to fail.
-            # Make everything unique by adding -<target_major> to the repoid.
-            target_repo = copy.deepcopy(source_repo)
-            target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
-            # releasever may be something like 8.6, while only 8 is acceptable.
-            target_repo.baseurl = target_repo.baseurl.replace("/cl$releasever/", "/cl{}/".format(target_major))
-
-            # Old CL MySQL versions (5.0 and 5.1) won't be available in CL8+.
-            if any(ver in target_repo.baseurl for ver in OLD_CLMYSQL_VERSIONS):
-                reporting.create_report(
-                    [
-                        reporting.Title("An old CL-MySQL version will no longer be available in EL{}".format(target_major)),
-                        reporting.Summary(
-                            "An old CloudLinux-provided MySQL version is installed on this system. "
-                            "It will no longer be available on the target system. "
-                            "This situation cannot be automatically resolved by Leapp. "
-                            "Problematic repository: {0}".format(target_repo.repoid)
-                        ),
-                        reporting.Severity(reporting.Severity.MEDIUM),
-                        reporting.Groups([reporting.Groups.REPOSITORY]),
-                        reporting.Groups([reporting.Groups.INHIBITOR]),
-                        reporting.Remediation(
-                            hint=(
-                                "Upgrade to a more recent MySQL version, or "
-                                "uninstall the deprecated MySQL packages and disable the repository. "
-                                "Note that you will also need to update any bindings (e.g., PHP or Python) "
-                                "that are dependent on this MySQL version."
-                            )
-                        ),
-                    ]
-                )
-
-            # Governor-managed MySQL/MariaDB repos may all be disabled, but we still
-            # need them enabled for the target system so DNF can upgrade the packages.
-            # Force-enable both cl-mysql-meta and mysqclient target repos.
-            if target_repo.enabled or target_repo.repoid in (
-                "mysqclient-{}".format(target_major),
-                "cl-mysql-meta-{}".format(target_major),
-            ):
-                api.current_logger().debug("Generating custom cl-mysql repo: {}".format(target_repo.repoid))
-                self.custom_repo_msgs.append(
-                    CustomTargetRepository(
-                        repoid=target_repo.repoid,
-                        name=target_repo.name,
-                        baseurl=target_repo.baseurl,
-                        enabled=True,
-                    )
-                )
-                self.mapping_msgs.append(
-                    construct_repomap_data(source_repo.repoid, target_repo.repoid)
-                )
-                # Gather the enabled repositories for the new repofile.
-                # They'll be used to create a new custom repofile for the target userspace.
-                cl_target_repofile_list.append(target_repo)
-
-        # Always register the cloudlinux type when CL MySQL/MariaDB is detected.
-        # Even if all repos in cl-mysql.repo are disabled (can happen with Governor),
-        # we still need the target repos for packages like mysqlclient that were
-        # installed from local RPMs and have no repo association.
-        self.mysql_types.add("cloudlinux")
-        # Provide the object with the modified repository data to the target userspace.
-        cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
-        leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
-        api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-
-    def _make_upgrade_mariadb_url(self, mariadb_url, source_major, target_major):
-        """
-        Maria URLs look like this:
-          baseurl = https://archive.mariadb.org/mariadb-10.3/yum/centos/7/x86_64
-          baseurl = https://archive.mariadb.org/mariadb-10.7/yum/centos7-ppc64/
-          baseurl = https://distrohub.kyiv.ua/mariadb/yum/11.8/rhel/$releasever/$basearch
-          baseurl = https://mariadb.gb.ssimn.org/yum/12.0/centos/$releasever/$basearch
-          baseurl = https://mariadb.gb.ssimn.org/yum/12.0/almalinux8-amd64/$releasever/$basearch
-        We want to replace the parts of the url to make them work with target os version.
-        """
-
-        # Replace the first occurrence of source_major with target_major after 'yum'
-        url_parts = mariadb_url.split("yum", 1)
-        if len(url_parts) == 2:
-            # Replace major version in "/centos/7/" and /12.0/almalinux9-amd64/,
-            # but do not replace it in /mariadb-10.7/yum/
-            url_parts[1] = url_parts[1].replace("/{}/".format(source_major), "/{}/".format(target_major))
-            url_parts[1] = url_parts[1].replace("{}-".format(source_major), "{}-".format(target_major))
-            # Replace $releasever because upstream repos expect major version
-            # and cloudlinux provides major.minor as $releasever
-            url_parts[1] = url_parts[1].replace('$releasever', str(target_major))
-            return "yum".join(url_parts)
-        else:
-            api.current_logger().warning("Unsupported repository URL={}, skipping".format(mariadb_url))
-            return
-
-    def mariadb_process(self, repofile_name, repofile_data):
-        """
-        Process upstream MariaDB options.
-
-        Versions of MariaDB installed from https://mariadb.org/.
-        """
-        cl_target_repofile_list = []
-        target_major = get_target_major_version()
-        source_major = get_source_major_version()
-
-        for source_repo in repofile_data.data:
-            target_repo = copy.deepcopy(source_repo)
-            target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
-            target_repo.baseurl = self._make_upgrade_mariadb_url(source_repo.baseurl, source_major, target_major)
-
-            if target_repo.enabled:
-                # MariaDB 10.4 is not compatible with Leapp upgrade
-                if str(source_major) == "8" and any(ver in target_repo.baseurl for ver in OLD_MARIADB_UPSTREAM_VERSIONS_CL8):
-                    reporting.create_report(
-                        [
-                            reporting.Title("MariaDB version is not compatible with Leapp upgrade"),
-                            reporting.Summary(
-                                "MariaDB is installed on this system but its version is not compatible with Leapp upgrade process. "
-                                "The upgrade is blocked to prevent system instability. "
-                                "This situation cannot be automatically resolved by Leapp. "
-                                "Problematic repository: {0}".format(target_repo.repoid)
-                            ),
-                            reporting.Severity(reporting.Severity.MEDIUM),
-                            reporting.Groups([reporting.Groups.REPOSITORY]),
-                            reporting.Groups([reporting.Groups.INHIBITOR]),
-                            reporting.Remediation(
-                                hint=(
-                                    "Upgrade to a more recent MariaDB version, or "
-                                    "uninstall the MariaDB packages and disable the repository. "
-                                    "Note that you will also need to update any bindings (e.g., PHP or Python) "
-                                    "that are dependent on this MariaDB version."
-                                )
-                            ),
-                        ]
-                    )
-
-                api.current_logger().debug("Generating custom MariaDB repo: {}".format(target_repo.repoid))
-                self.custom_repo_msgs.append(
-                    CustomTargetRepository(
-                        repoid=target_repo.repoid,
-                        name=target_repo.name,
-                        baseurl=target_repo.baseurl,
-                        enabled=target_repo.enabled,
-                    )
-                )
-                self.mapping_msgs.append(
-                    construct_repomap_data(source_repo.repoid, target_repo.repoid)
-                )
-                cl_target_repofile_list.append(target_repo)
-
-        if any(repo.enabled for repo in repofile_data.data):
-            # Since MariaDB URLs have major versions written in, we need a new repo file
-            # to feed to the target userspace.
-            self.mysql_types.add("mariadb")
-            cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
-            leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
-            api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-        else:
-            api.current_logger().debug("No repos from MariaDB repofile {} enabled, ignoring".format(repofile_name))
-
-    def mysql_process(self, repofile_name, repofile_data):
-        """
-        Process upstream MySQL options.
-
-        Versions of MySQL installed from https://mysql.com/.
-        """
-        cl_target_repofile_list = []
-        target_major = get_target_major_version()
-        source_major = get_source_major_version()
-
-        # Select the correct list of old MySQL versions for the source major version
-        if str(source_major) == "7":
-            old_mysql_versions = OLD_MYSQL_UPSTREAM_VERSIONS_CL7
-        else:
-            old_mysql_versions = OLD_MYSQL_UPSTREAM_VERSIONS_CL8
-
-        for source_repo in repofile_data.data:
-            # URLs look like this:
-            # baseurl = https://repo.mysql.com/yum/mysql-8.0-community/el/7/x86_64/
-            # Remember that we always want to modify names, to avoid "duplicate repository" errors.
-            target_repo = copy.deepcopy(source_repo)
-            target_repo.repoid = "{}-{}".format(target_repo.repoid, target_major)
-            # Replace /el/<source_major>/ with /el/<target_major>/
-            target_repo.baseurl = target_repo.baseurl.replace("/el/{}/".format(source_major), "/el/{}/".format(target_major))
-            # releasever may be something like 8.6, while only 8 is acceptable.
-            target_repo.baseurl = target_repo.baseurl.replace("/$releasever/", "/{}/".format(target_major))
-
-            if target_repo.enabled:
-                # MySQL package repos don't have these versions available for EL8 anymore.
-                # There's only 8.0 available.
-                # There'll be nothing to upgrade to.
-                # CL repositories do provide them, though.
-                if any(ver in target_repo.name for ver in old_mysql_versions):
-                    reporting.create_report(
-                        [
-                            reporting.Title("An old MySQL version will no longer be available in EL{}".format(target_major)),
-                            reporting.Summary(
-                                "A yum repository for an old MySQL version is enabled on this system. "
-                                "It will no longer be available on the target system. "
-                                "This situation cannot be automatically resolved by Leapp. "
-                                "Problematic repository: {0}".format(target_repo.repoid)
-                            ),
-                            reporting.Severity(reporting.Severity.MEDIUM),
-                            reporting.Groups([reporting.Groups.REPOSITORY]),
-                            reporting.Groups([reporting.Groups.INHIBITOR]),
-                            reporting.Remediation(
-                                hint=(
-                                    "Upgrade to a more recent MySQL version, "
-                                    "uninstall the deprecated MySQL packages and disable the repository, "
-                                    "or switch to CloudLinux MySQL Governor-provided version of MySQL to "
-                                    "continue using the old MySQL version."
-                                )
-                            ),
-                        ]
-                    )
-                api.current_logger().debug("Generating custom MySQL repo: {}".format(target_repo.repoid))
-                self.custom_repo_msgs.append(
-                    CustomTargetRepository(
-                        repoid=target_repo.repoid,
-                        name=target_repo.name,
-                        baseurl=target_repo.baseurl,
-                        enabled=target_repo.enabled,
-                    )
-                )
-                self.mapping_msgs.append(
-                    construct_repomap_data(source_repo.repoid, target_repo.repoid)
-                )
-                cl_target_repofile_list.append(target_repo)
-
-        if any(repo.enabled for repo in repofile_data.data):
-            # MySQL typically has multiple repo files, so we want to make sure we're
-            # adding the type to list only once.
-            self.mysql_types.add("mysql")
-            cl_target_repofile_data = RepositoryFile(data=cl_target_repofile_list, file=repofile_data.file)
-            leapp_repocopy = create_leapp_repofile_copy(cl_target_repofile_data, repofile_name)
-            api.produce(CustomTargetRepositoryFile(file=leapp_repocopy))
-        else:
-            api.current_logger().debug("No repos from MySQL repofile {} enabled, ignoring".format(repofile_name))
 
     def finalize(self):
         """Use the data collected to produce messages and reports."""
@@ -520,20 +190,20 @@ class MySqlRepositorySetupLibrary(object):
                 api.current_logger().debug(
                     "Processing CL-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
                 )
-                self.clmysql_process(repofile_name, repofile_data)
+                clmysql_process(self, repofile_name, repofile_data)
 
             # Process MariaDB options.
             elif any(mark in repofile_name for mark in MARIA_MARKERS):
                 api.current_logger().debug(
                     "Processing MariaDB-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
                 )
-                self.mariadb_process(repofile_name, repofile_data)
+                mariadb_process(self, repofile_name, repofile_data)
 
             # Process MySQL options.
             elif any(mark in repofile_name for mark in MYSQL_MARKERS):
                 api.current_logger().debug(
                     "Processing MySQL-related repofile {}, full path: {}".format(repofile_full, full_repo_path)
                 )
-                self.mysql_process(repofile_name, repofile_data)
+                mysql_process(self, repofile_name, repofile_data)
 
         self.finalize()

--- a/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/tests/test_upgrade_mariadb_community.py
+++ b/repos/system_upgrade/cloudlinux/actors/clmysqlrepositorysetup/tests/test_upgrade_mariadb_community.py
@@ -1,6 +1,6 @@
 import pytest
 
-from leapp.libraries.actor import clmysqlrepositorysetup
+from leapp.libraries.actor.clmysql_upstream_mariadb import _make_upgrade_mariadb_url
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,6 @@ from leapp.libraries.actor import clmysqlrepositorysetup
 )
 def test_make_upgrade_mariadb_url(source_url, source_major, target_major, expected_url):
     """Test URL transformation for various MariaDB repository URLs."""
-    library = clmysqlrepositorysetup.MySqlRepositorySetupLibrary()
-    result = library._make_upgrade_mariadb_url(source_url, source_major, target_major)
+    result = _make_upgrade_mariadb_url(source_url, source_major, target_major)
 
     assert result == expected_url

--- a/repos/system_upgrade/cloudlinux/libraries/clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/clmysql.py
@@ -1,10 +1,15 @@
 import collections
 import os
 import re
-import shutil
 from enum import Enum
 
+from leapp.libraries.common.config.version import get_source_major_version, get_target_major_version
 from leapp.libraries.stdlib import CalledProcessError, api, run
+from leapp.models import (
+    PESIDRepositoryEntry,
+    RepoMapEntry,
+    RepositoriesMapping,
+)
 
 
 class ClMysqlTypeStatus(Enum):
@@ -76,11 +81,18 @@ def resolve_clmysql_module_stream(clmysql_type):
 
 def _resolve_mysqld_path():
     """
-    Return absolute path to mysqld: PATH first, then usual daemon locations.
+    Return absolute path to mysqld: ``which`` first, then usual daemon locations.
+
+    Uses a subprocess call instead of :func:`shutil.which` so the code works on
+    Python 2.7 (EL7) where ``shutil.which`` does not exist.
     """
-    path = shutil.which("mysqld")
-    if path:
-        return path
+    try:
+        result = run(["which", "mysqld"])
+        path = result["stdout"].strip()
+        if path:
+            return path
+    except (CalledProcessError, OSError):
+        pass
     for candidate in ("/usr/sbin/mysqld", "/usr/libexec/mysqld", "/usr/bin/mysqld"):
         if os.path.isfile(candidate):
             return candidate
@@ -171,6 +183,40 @@ def get_pkg_prefix(clmysql_type):
         return None
 
 
+def get_expected_repo_url_fragment(clmysql_type):
+    """
+    Derive the expected cl-mysql-meta repo URL path fragment from the detected DB type.
+
+    Governor writes cl-mysql.repo with a baseurl like::
+
+        http://repo.cloudlinux.com/other/cl$releasever/mysqlmeta/cl-mariadb-10.6/$basearch/
+
+    The path component (``cl-mariadb-10.6``) is determined by the DB type.  This function
+    returns that expected fragment so callers can validate the repo URL.
+
+    :param clmysql_type: type string like ``mariadb106``, ``mysql57``, ``percona56``
+    :returns: expected path fragment like ``cl-mariadb-10.6``, or None if the type is
+              not recognised.
+    """
+    if not clmysql_type:
+        return None
+    # Match family + version digits: mariadb106 -> ("mariadb", "106")
+    m = re.match(r"^(mariadb|mysql|percona)(\d+)$", clmysql_type)
+    if not m:
+        return None
+    family, digits = m.group(1), m.group(2)
+    # Split digits into major.minor.  Governor concatenates major and minor:
+    #   "57" -> "5.7",  "80" -> "8.0"       (2-digit: single-digit major)
+    #   "106" -> "10.6", "100" -> "10.0"     (3-digit: two-digit major)
+    #   "1011" -> "10.11", "1104" -> "11.04" (4-digit: two-digit major)
+    # All known DB majors <= 2 digits; the split point is 1 for short, 2 otherwise.
+    if len(digits) <= 2:
+        major, minor = digits[:1], digits[1:]
+    else:
+        major, minor = digits[:2], digits[2:]
+    return "cl-{}-{}.{}".format(family, major, minor)
+
+
 def _get_clmysql_type_from_governor():
     """
     Read the actually installed DB type from the MySQL Governor cache file.
@@ -233,4 +279,38 @@ def get_clmysql_type():
         status=ClMysqlTypeStatus.OK,
         governor_type=governor_type,
         pkg_type=pkg_type,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Repository mapping helpers
+# ---------------------------------------------------------------------------
+
+def make_pesid_repo(pesid, major_version, repoid, arch='x86_64', repo_type='rpm', channel='ga', rhui=''):
+    """
+    PESIDRepositoryEntry factory function allowing shorter data description by providing default values.
+    """
+    return PESIDRepositoryEntry(
+        pesid=pesid,
+        major_version=major_version,
+        repoid=repoid,
+        arch=arch,
+        repo_type=repo_type,
+        channel=channel,
+        rhui=rhui
+    )
+
+
+def construct_repomap_data(source_id, target_id):
+    """
+    Construct the repository mapping data.
+    """
+    source_major = get_source_major_version()
+    target_major = get_target_major_version()
+    return RepositoriesMapping(
+        mapping=[RepoMapEntry(source=source_id, target=[target_id])],
+        repositories=[
+            make_pesid_repo(source_id, source_major, source_id),
+            make_pesid_repo(target_id, target_major, target_id)
+        ]
     )

--- a/repos/system_upgrade/cloudlinux/libraries/tests/test_clmysql.py
+++ b/repos/system_upgrade/cloudlinux/libraries/tests/test_clmysql.py
@@ -8,6 +8,7 @@ from leapp.libraries.common.clmysql import (
     _get_clmysql_type_from_governor,
     _resolve_mysqld_path,
     get_clmysql_type,
+    get_expected_repo_url_fragment,
     get_pkg_prefix,
     resolve_clmysql_module_stream,
 )
@@ -68,11 +69,19 @@ class TestResolveClmysqlModuleStream(object):
 class TestResolveMysqldPath(object):
 
     def test_found_via_which(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/mysqld")
+        monkeypatch.setattr(
+            "leapp.libraries.common.clmysql.run",
+            lambda cmd: {"stdout": "/usr/bin/mysqld\n"},
+        )
         assert _resolve_mysqld_path() == "/usr/bin/mysqld"
 
     def test_fallback_to_standard_location(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _name: None)
+        from leapp.libraries.stdlib import CalledProcessError
+
+        def which_fails(cmd):
+            raise CalledProcessError("not found", cmd, {})
+
+        monkeypatch.setattr("leapp.libraries.common.clmysql.run", which_fails)
         # Only /usr/libexec/mysqld "exists"
         monkeypatch.setattr(
             "os.path.isfile",
@@ -81,7 +90,12 @@ class TestResolveMysqldPath(object):
         assert _resolve_mysqld_path() == "/usr/libexec/mysqld"
 
     def test_not_found(self, monkeypatch):
-        monkeypatch.setattr("shutil.which", lambda _name: None)
+        from leapp.libraries.stdlib import CalledProcessError
+
+        def which_fails(cmd):
+            raise CalledProcessError("not found", cmd, {})
+
+        monkeypatch.setattr("leapp.libraries.common.clmysql.run", which_fails)
         monkeypatch.setattr("os.path.isfile", lambda _p: False)
         assert _resolve_mysqld_path() is None
 
@@ -182,6 +196,40 @@ class TestGetClmysqlTypeFromGovernor(object):
             "leapp.libraries.common.clmysql.GOVERNOR_INSTALLED_TYPE_FILE", str(f)
         )
         assert _get_clmysql_type_from_governor() is None
+
+
+# ---------------------------------------------------------------------------
+# get_expected_repo_url_fragment
+# ---------------------------------------------------------------------------
+
+class TestGetExpectedRepoUrlFragment(object):
+    """Validate that the type-to-URL-fragment mapping matches Governor's REPO_NAMES."""
+
+    @pytest.mark.parametrize(
+        "clmysql_type,expected",
+        [
+            ("mysql51", "cl-mysql-5.1"),
+            ("mysql55", "cl-mysql-5.5"),
+            ("mysql57", "cl-mysql-5.7"),
+            ("mysql80", "cl-mysql-8.0"),
+            ("mysql84", "cl-mysql-8.4"),
+            ("mariadb55", "cl-mariadb-5.5"),
+            ("mariadb100", "cl-mariadb-10.0"),
+            ("mariadb106", "cl-mariadb-10.6"),
+            ("mariadb1011", "cl-mariadb-10.11"),
+            ("mariadb1104", "cl-mariadb-11.04"),
+            ("percona56", "cl-percona-5.6"),
+        ],
+    )
+    def test_known_types(self, clmysql_type, expected):
+        assert get_expected_repo_url_fragment(clmysql_type) == expected
+
+    @pytest.mark.parametrize(
+        "clmysql_type",
+        [None, "", "unknown", "postgres15"],
+    )
+    def test_unrecognised(self, clmysql_type):
+        assert get_expected_repo_url_fragment(clmysql_type) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Unusual state was observed on one of client machines: Governor is set to mariadb106, packages are the same, but baseurl for cl-mysql-meta is set to mysql57. A state like this is problematic for multiple reasons, but the most important is that we can't do what we do normally in the actor: use old cl-mysql-meta repo configs with OS version replaced in the Leapp transaction to upgrade CL DB packages.

The best approach seems to be to check the correctness of the cl-mysql-meta URL in the actor and fail if it is not correct.

Code of the actor libs broken into separate files for better readability and maintainability. The library file was growing too big with the recent changes.