### PR TITLE
Rebuild rpmdb before dnf transactions targeting el9 to silence bdb_ro warnings

### DIFF
--- a/repos/system_upgrade/common/libraries/dnfplugin.py
+++ b/repos/system_upgrade/common/libraries/dnfplugin.py
@@ -483,6 +483,8 @@ def _prepare_perform(used_repos, target_userspace_info, xfs_info, storage_info, 
                                               mount_target=os.path.join(context.base_dir, 'installroot'),
                                               scratch_reserve=reserve_space) as overlay:
             with mounting.mount_upgrade_iso_to_root_dir(target_userspace_info.path, target_iso):
+                if get_target_major_version() == '9':
+                    _rebuild_rpm_db(context, root='/installroot')
                 yield context, overlay, target_repoids
 
 


### PR DESCRIPTION
When upgrading to RHEL/AlmaLinux 9, the target DNF (SQLite-default) emits repeated "Found bdb_ro Packages database" warnings because the source system's RPM database is in Berkeley DB format.
Adding _rebuild_rpm_db to _prepare_perform converts the overlay copy once, consistent with perform_transaction_install and install_initramdisk_requirements which already do the same.