### PR TITLE
CLOS-3960: Fix EnableYumSpacewalkPlugin actor for CL7 -> CL8 upgrade

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/actor.py
@@ -3,55 +3,25 @@ from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
 from leapp import reporting
 from leapp.reporting import Report
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
-
-
-try:
-    # py2
-    import ConfigParser as configparser
-    ParserClass = configparser.SafeConfigParser
-except Exception:
-    # py3
-    import configparser
-    ParserClass = configparser.ConfigParser
+from leapp.libraries.actor import enableyumspacewalkplugin
 
 
 class EnableYumSpacewalkPlugin(Actor):
-    """
-    Enable yum spacewalk plugin if it's disabled
-    Required for the CLN channel functionality to work properly
-    """
-
-    name = 'enable_yum_spacewalk_plugin'
+    name = "enable_yum_spacewalk_plugin"
     consumes = ()
     produces = (Report,)
     tags = (FirstBootPhaseTag, IPUWorkflowTag)
-
-    config = '/etc/yum/pluginconf.d/spacewalk.conf'
+    config = enableyumspacewalkplugin.DEFAULT_CONFIG_PATH
 
     @run_on_cloudlinux
     def process(self):
-        summary = 'yum spacewalk plugin must be enabled for the CLN channels to work properly. ' \
-            'Please make sure it is enabled. Default config path is "%s"' % self.config
-        title = None
-
-        parser = ParserClass(allow_no_value=True)
-        try:
-            red = parser.read(self.config)
-            if not red:
-                title = 'yum spacewalk plugin config not found'
-            if parser.get('main', 'enabled') != '1':
-                parser.set('main', 'enabled', '1')
-                with open(self.config, 'w') as f:
-                    parser.write(f)
-                self.log.info('yum spacewalk plugin enabled')
-                return
-        except Exception as e:
-            title = 'yum spacewalk plugin config error: %s' % e
-
+        _, title = enableyumspacewalkplugin._enable_plugin(
+            self.config, enableyumspacewalkplugin.ParserClass, self.log
+        )
         if title:
             reporting.create_report([
                 reporting.Title(title),
-                reporting.Summary(summary),
+                reporting.Summary("DNF spacewalk plugin must be enabled for CLN channels. Config path: " + self.config),
                 reporting.Severity(reporting.Severity.MEDIUM),
                 reporting.Groups([reporting.Groups.SANITY])
             ])

--- a/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/libraries/enableyumspacewalkplugin.py
+++ b/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/libraries/enableyumspacewalkplugin.py
@@ -1,0 +1,46 @@
+import os
+
+try:
+    # py2
+    import ConfigParser as configparser
+    ParserClass = configparser.SafeConfigParser
+except ImportError:
+    # py3
+    import configparser
+    ParserClass = configparser.ConfigParser
+
+
+# DNF plugin config path on the target system (CL8). FirstBoot runs after the
+# target OS is already in place; on CL8 the plugin package is
+# dnf-plugin-spacewalk (PES replacement for CL7's yum-rhn-plugin,
+# pes-events id=1586) and its config ships with enabled=0.
+DEFAULT_CONFIG_PATH = '/etc/dnf/plugins/spacewalk.conf'
+
+
+def _enable_plugin(config_path, parser_cls=ParserClass, log=None):
+    """Enable the DNF spacewalk plugin at `config_path`.
+
+    Returns `(changed, title)` where `title` is `None` on success or
+    when the plugin is not installed, and otherwise a human-readable
+    problem description suitable for a Leapp report.
+
+    Absence of `config_path` is treated as a silent skip: on no-auth /
+    SWNG systems (CLOS-4056) `rhn-client-tools >= 3.0.1` Obsoletes the
+    `dnf-plugin-spacewalk` package, so the config file is either gone by
+    then, or doesn't do anything.
+    """
+    if not os.path.exists(config_path):
+        return False, None
+    parser = parser_cls(allow_no_value=True)
+    try:
+        parser.read(config_path)
+        if parser.get('main', 'enabled') != '1':
+            parser.set('main', 'enabled', '1')
+            with open(config_path, 'w') as f:
+                parser.write(f)
+            if log is not None:
+                log.info('DNF spacewalk plugin enabled')
+            return True, None
+        return False, None
+    except Exception as e:
+        return False, 'DNF spacewalk plugin config error: %s' % e

--- a/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/tests/test_enableyumspacewalkplugin.py
+++ b/repos/system_upgrade/cloudlinux/actors/enableyumspacewalkplugin/tests/test_enableyumspacewalkplugin.py
@@ -1,0 +1,57 @@
+try:
+    import ConfigParser as configparser  # py2
+    ParserClass = configparser.SafeConfigParser
+except ImportError:
+    import configparser  # py3
+    ParserClass = configparser.ConfigParser
+
+from leapp.libraries.actor.enableyumspacewalkplugin import _enable_plugin
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "spacewalk.conf"
+    p.write_text(body)
+    return str(p)
+
+
+def test_missing_config_is_silent_skip(tmp_path):
+    """Config file absent -> silent skip: no change, no title, no report.
+
+    On no-auth / SWNG systems (CLOS-4056) the dnf-plugin-spacewalk
+    package is Obsoleted by rhn-client-tools >= 3.0.1 and the config
+    file is absent by design. Emitting a 'not found' report there
+    would be noise.
+    """
+    changed, title = _enable_plugin(str(tmp_path / "absent.conf"), ParserClass)
+    assert changed is False
+    assert title is None
+
+
+def test_flips_enabled_zero_to_one(tmp_path):
+    """Config present with enabled=0 -> flipped to 1, changed=True, no title."""
+    cfg = _write(tmp_path, "[main]\nenabled = 0\n")
+    changed, title = _enable_plugin(cfg, ParserClass)
+    assert changed is True
+    assert title is None
+    updated = open(cfg).read()
+    # ConfigParser may write either 'enabled = 1' or 'enabled=1'; accept both.
+    assert "enabled = 1" in updated or "enabled=1" in updated
+
+
+def test_already_enabled_is_noop(tmp_path):
+    """Config present with enabled=1 -> no change, no title, file untouched."""
+    cfg = _write(tmp_path, "[main]\nenabled = 1\n")
+    original = open(cfg).read()
+    changed, title = _enable_plugin(cfg, ParserClass)
+    assert changed is False
+    assert title is None
+    assert open(cfg).read() == original
+
+
+def test_missing_main_section_returns_config_error(tmp_path):
+    """Config present but missing [main] -> title reports config error."""
+    cfg = _write(tmp_path, "[other]\nenabled = 0\n")
+    changed, title = _enable_plugin(cfg, ParserClass)
+    assert changed is False
+    assert title is not None
+    assert "config error" in title.lower()


### PR DESCRIPTION
The FirstBoot-phase actor that re-enables the spacewalk plugin after a CL7 -> CL8 upgrade had several defects that combined to leave the plugin disabled on CL8 and break CLN dynamic channel resolution.

The main one is the hardcoded YUM path /etc/yum/pluginconf.d/spacewalk.conf, which does not exist on the target system. After the PES replacement yum-rhn-plugin -> dnf-plugin-spacewalk (pes-events id=1586) the CL8 plugin config lives at /etc/dnf/plugins/spacewalk.conf.

Fix: point self.config at the DNF path and split the logic into a pure helper _enable_plugin() in libraries/enableyumspacewalkplugin.py.

Under the no-auth / SWNG transition (CLOS-4056) rhn-client-tools >= 3.0.1 Obsoletes dnf-plugin-spacewalk, so the config file is gone by design on no-auth systems; emitting a "config not found" report there would just be noise.

Plugin-config presence is the discriminator: we enable it whether it's found. On a system that transitions to no-auth it won't matter, because the plugin is gone.