### PR TITLE
CLOS-4332: Exclude elevate repos from "unknown to Leapp" report

### DIFF
--- a/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/libraries/setuptargetrepos.py
@@ -77,6 +77,18 @@ def _get_mapped_repoids(repomap, src_repoids):
     return mapped_repoids
 
 
+def _get_skipped_repoids(enabled_repoids, mapped_repoids, used_repoids):
+    """
+    Return the set of source-system repoids whose packages may be left behind.
+
+    Excludes elevate repositories: their packages are leapp tooling itself,
+    intentionally not carried into the target system, so reporting them as
+    "unknown to Leapp" is a false positive.
+    """
+    skipped = enabled_repoids & used_repoids - mapped_repoids
+    return {repoid for repoid in skipped if "elevate" not in repoid}
+
+
 def _get_vendor_custom_repos(enabled_repos, mapping_list):
     # Look at what source repos from the vendor mapping were enabled.
     # If any of them are in beta, include vendor's custom repos in the list.
@@ -200,7 +212,9 @@ def process():
 
     # produce message about skipped repositories
     enabled_repoids_with_mapping = _get_mapped_repoids(repomap, enabled_repoids)
-    skipped_repoids = enabled_repoids & set(used_repoids_dict.keys()) - enabled_repoids_with_mapping
+    skipped_repoids = _get_skipped_repoids(
+        enabled_repoids, enabled_repoids_with_mapping, set(used_repoids_dict.keys())
+    )
     if skipped_repoids:
         pkgs = set()
         for repo in skipped_repoids:

--- a/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_setuptargetrepos.py
+++ b/repos/system_upgrade/common/actors/setuptargetrepos/tests/test_setuptargetrepos.py
@@ -16,7 +16,10 @@ from leapp.models import (
     RepositoryData,
     RepositoryFile,
     RPM,
-    TargetRepositories
+    SkippedRepositories,
+    TargetRepositories,
+    UsedRepositories,
+    UsedRepository
 )
 
 RH_PACKAGER = 'Red Hat, Inc. <http://bugzilla.redhat.com/bugzilla>'
@@ -194,3 +197,63 @@ def test_repos_mapping(monkeypatch):
     expected_rhel_repoids = {'rhel-8-for-x86_64-baseos-htb-rpms', 'rhel-8-for-x86_64-appstream-htb-rpms',
                              'rhel-8-for-x86_64-satellite-extras-rpms'}
     assert produced_rhel_repoids == expected_rhel_repoids
+
+
+def test_skipped_repos_excludes_elevate(monkeypatch):
+    """
+    The "Some enabled RPM repositories are unknown to Leapp" report must not
+    flag elevate repos: their packages are leapp tooling itself, intentionally
+    not upgraded. A regression here drops the filter and re-introduces the
+    false positive (CLOS-4332).
+    """
+    repos_data = [
+        RepositoryData(repoid='cloudlinux-elevate', name='CloudLinux ELevate', enabled=True),
+        RepositoryData(repoid='unmapped-third-party', name='Unmapped Third Party', enabled=True),
+    ]
+    facts = RepositoriesFacts(
+        repositories=[RepositoryFile(file='/etc/yum.repos.d/test.repo', data=repos_data)]
+    )
+    used = UsedRepositories(repositories=[
+        UsedRepository(repository='cloudlinux-elevate', packages=['leapp', 'python2-leapp']),
+        UsedRepository(repository='unmapped-third-party', packages=['something']),
+    ])
+    repomap = RepositoriesMapping(mapping=[], repositories=[])
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts, used, repomap]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    setuptargetrepos.process()
+
+    skipped = [m for m in api.produce.model_instances if isinstance(m, SkippedRepositories)]
+    assert len(skipped) == 1
+    assert skipped[0].repos == ['unmapped-third-party']
+    # Packages from elevate repos must not leak into the report either.
+    assert 'leapp' not in skipped[0].packages
+    assert 'python2-leapp' not in skipped[0].packages
+
+
+def test_skipped_repos_empty_when_only_elevate(monkeypatch):
+    """
+    If the only unmapped+used repos are elevate repos, no SkippedRepositories
+    message should be produced - the report would be entirely false-positive.
+    """
+    repos_data = [
+        RepositoryData(repoid='cloudlinux-elevate', name='CloudLinux ELevate', enabled=True),
+        RepositoryData(repoid='cloudlinux8-elevate', name='CloudLinux 8 ELevate', enabled=True),
+    ]
+    facts = RepositoriesFacts(
+        repositories=[RepositoryFile(file='/etc/yum.repos.d/test.repo', data=repos_data)]
+    )
+    used = UsedRepositories(repositories=[
+        UsedRepository(repository='cloudlinux-elevate', packages=['leapp']),
+        UsedRepository(repository='cloudlinux8-elevate', packages=['leapp-data-cloudlinux']),
+    ])
+    repomap = RepositoriesMapping(mapping=[], repositories=[])
+
+    monkeypatch.setattr(api, 'current_actor', CurrentActorMocked(msgs=[facts, used, repomap]))
+    monkeypatch.setattr(api, 'produce', produce_mocked())
+
+    setuptargetrepos.process()
+
+    skipped = [m for m in api.produce.model_instances if isinstance(m, SkippedRepositories)]
+    assert skipped == []


### PR DESCRIPTION
The setuptargetrepos actor produces SkippedRepositories for repoids that are enabled and used on the source system but have no entry in the combined repomap. CheckSkippedRepositories then renders them as the "Some enabled RPM repositories are unknown to Leapp" report.

ELevate's own repository (cloudlinux-elevate, installed by the elevate-release package) is always one of those: it carries leapp, leapp-data-cloudlinux, and similar tooling that is intentionally left unupgraded, so flagging it as a coverage gap is a false positive.

A previous fix (commit da609c68) added a "elevate" filter to skip these repoids, but it was lost during the v0.19.0 vendor-mechanism rebase (70f49e0d), which restored the unfiltered upstream expression. Restore the filter as a dedicated helper.