### PR TITLE
CLOS-2598: Remove dead lua_cjson_handle from ClearPackageConflicts

### DIFF
--- a/repos/system_upgrade/cloudlinux/actors/clearpackageconflicts/libraries/clearpackageconflicts.py
+++ b/repos/system_upgrade/cloudlinux/actors/clearpackageconflicts/libraries/clearpackageconflicts.py
@@ -59,25 +59,6 @@ def alt_python37_handle(package_lookup):
         clear_problem_files(problem_files, problem_dirs)
 
 
-def lua_cjson_handle(package_lookup):
-    """
-    lua-cjson package is conflicting with the incoming lua-cjson package for EL8.
-    """
-    problem_packages = [
-        "lua-cjson"
-    ]
-    problem_files = [
-        "/usr/lib64/lua/5.1/cjson.so",
-        "/usr/share/lua/5.1/cjson/tests/bench.lua",
-        "/usr/share/lua/5.1/cjson/tests/genutf8.pl",
-        "/usr/share/lua/5.1/cjson/tests/test.lua",
-    ]
-    problem_dirs = []
-
-    if problem_packages_installed(problem_packages, package_lookup):
-        clear_problem_files(problem_files, problem_dirs)
-
-
 def process():
     rpm_lookup = set()
     # Each InstalledRPM is a list of RPM objects.


### PR DESCRIPTION
The lua-cjson -> lua51-cjson swap on CL7 -> CL8 is now handled by a PES Replaced event in leapp-data (cloudlinux/pes-events.json), which makes DNF remove lua-cjson in the same transaction that installs lua51-cjson. The actor-level file-removal helper was never wired into process() and is no longer needed.