### PR TITLE
packaging: catch up the changelog from 0.20.0-1 through 0.20.0-10

### DIFF
--- a/packaging/leapp-repository-changelog.txt
+++ b/packaging/leapp-repository-changelog.txt
@@ -1,3 +1,63 @@
+* Thu Aug 06 2026 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.20.0-10.cloudlinux
+- CLOS-2132: Warn before the upgrade when the PostgreSQL configuration would keep the database from starting on the new system, and spell out the migration steps to run afterwards
+- CLOS-3716: Stop the upgrade when the target repositories offer a kernel newer than the rest of the target system, which could leave LVE unusable after the reboot
+- CLOS-4330: Stop the upgrade when NetworkManager is configured to manage no devices, which would leave the upgraded system without networking
+- CLOS-4726: Fix the upgrade failing to install the CloudLinux 8 release package because of a conflict with the CloudLinux 7 CLN client tools
+- CLOS-6840: Fix an unusable MariaDB repository being generated for upstream MariaDB URLs, and explain why an unsupported MariaDB version blocks the upgrade
+
+* Sun May 17 2026 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.20.0-9.cloudlinux
+- CLOS-2598: Fix the lua-cjson package conflicting with its own upgrade during CloudLinux 7 to CloudLinux 8 upgrades
+- CLOS-2816: Fix the upgrade failing while trying to create an oversized scratch disk image
+- CLOS-2842: Fix creation of the upgrade boot entry on systems with a hybrid BIOS and UEFI boot layout
+- CLOS-3465: Stop the upgrade when '_netdev' mount points are present in /etc/fstab, because they cannot be mounted after the first reboot
+- CLOS-3960: Fix CLN plugin activation failing on the first boot after a CloudLinux 7 to CloudLinux 8 upgrade
+- CLOS-4056: Support upgrades on systems that use CloudLinux package repositories without CLN registration, in addition to CLN-registered systems
+- CLOS-4332: Stop reporting CloudLinux and AlmaLinux repositories as unknown to Leapp when they are in fact mapped
+- Accept '--non-interactive' as an alias for the 'leapp upgrade --nowarn' option
+- Assorted internal maintenance and packaging improvements
+
+* Wed Apr 22 2026 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.20.0-8.cloudlinux
+- CLOS-3762: Fix MySQL and MariaDB module stream selection for CloudLinux MariaDB 10.11 and make the installed database version detection more reliable
+- CLOS-3827: Add a missing Imunify package signature to the list of trusted signatures
+- CLOS-3828: Fix the set of target repositories being incomplete when more than one repository mapping is available
+- CLOS-3833: Fix mysqlclient and cl-MySQL/cl-MariaDB packages not being upgraded when their repositories are disabled
+- CLOS-4259: Fix a Python 2.7 incompatibility on CloudLinux 7, and stop the upgrade when the cl-mysql repository file does not match the installed database
+- Stop the upgrade when the database type reported by MySQL Governor does not match the installed packages
+- Stop the upgrade, instead of only warning, when a system with a control panel does not match memory requirements
+
+* Sun Aug 17 2025 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> 0.20.0-7.cloudlinux
+- CLOS-3468: Support CloudLinux 8 to CloudLinux 9 upgrades on systems with cl-mysql repositories, and warn when an unsupported MariaDB repository URL is configured
+- CLOS-3489: Add cl-MySQL 8.4 and cl-MariaDB 11.4 to the database package mappings
+- CLOS-3490: Fix upgrades on systems that use the upstream MariaDB repository
+- Stop the upgrade when an outdated MariaDB version is installed, and explain what has to be done before upgrading
+
+* Fri May 23 2025 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.20.0-6.cloudlinux
+- CLOS-3344: Detect leftover package repository files created by cldeploy and handle them during the upgrade
+
+* Thu Feb 27 2025 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> 0.20.0-5.cloudlinux
+- CLOS-3202: Replace the rhn-client-tools version check with a package dependency
+- CLOS-3205: Fix errors raised by the package conflict resolution step during CloudLinux 8 to CloudLinux 9 upgrades
+- CLOS-3211: Switch the CLN channel only inside the upgrade container during preupgrade checks, leaving the running system untouched
+- CLOS-3224: Fix repository file parsing failing on CloudLinux 8
+- CLOS-3230: Refresh EPEL repositories that still point at the previous release after the upgrade, which could make the upgrade try to remove systemd
+- CLOS-3233: Fix mirror pinning not working during CloudLinux 8 to CloudLinux 9 upgrades
+- CLOS-3241: Create a marker file when the upgrade completes so that tooling can reliably detect the end of the process
+
+* Thu Feb 06 2025 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> 0.20.0-4.cloudlinux
+- CLOS-3200: Fix 'leapp preupgrade' failing with an 'unable to open database file' error
+
+* Mon Feb 03 2025 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> 0.20.0-3.cloudlinux
+- CLOS-3068: Report failed DNF commands as upgrade errors so that control panel tooling notices a failed preupgrade instead of continuing
+- CLOS-3187: Add support for upgrades from CloudLinux OS 8 to CloudLinux OS 9
+
+* Wed Sep 11 2024 Oleksandr Shyshatskyi <oshyshatskyi@cloudlinux.com> 0.20.0-2.cloudlinux
+- CLOS-2879: Require the versions of leapp and leapp-data-cloudlinux that contain the corrected alt-php package mappings
+
+* Fri Aug 30 2024 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.20.0-1.cloudlinux
+- CLOS-2615: Rebase the CloudLinux upgrade code onto upstream leapp-repository 0.20.0
+- CLOS-2786: Fix partition layout detection failing on systems whose boot partition is on a software RAID
+- Report the detected OS version together with the 'unsupported OS' inhibitor to make it easier to diagnose
+
 * Thu Jul 04 2024 Roman Prilipskii <rprilipskii@cloudlinux.com> 0.16.0-10.cloudlinux
 - CLOS-2610: Add upgrade inhibitors for outdated GRUB and insufficient space in boot disk embedding area
 - CLOS-2670: Allow upgrades with the Plesk control panel


### PR DESCRIPTION
The package changelog (packaging/leapp-repository-changelog.txt) had not been updated since 0.16.0-10.cloudlinux. Add the missing entries for every release since then.

Notes:
- 0.16.0-11.cloudlinux was tagged but never released; its two changes (CLOS-2786 and the checkosrelease diagnostics) reached users with the 0.20.0 rebase and are listed under 0.20.0-1.cloudlinux.
- Only the changelog file is touched. The spec %changelog is deliberately left alone.