### PR TITLE
CLOS-6911: remove SysV runlevel links that shadow a real unit after the upgrade

### DIFF
--- a/packaging/leapp-repository.spec
+++ b/packaging/leapp-repository.spec
@@ -42,7 +42,7 @@ py2_byte_compile "%1" "%2"}
 
 Name:           leapp-repository
 Version:        0.20.0
-Release:        11%{?dist}.cloudlinux
+Release:        12%{?dist}.cloudlinux
 Summary:        Repositories for leapp
 
 License:        ASL 2.0
@@ -298,6 +298,9 @@ done;
 
 # DO NOT TOUCH SECTION BELOW IN UPSTREAM
 %changelog
+* Wed Sep 02 2026 Roman Prilipskii <rprilipskii@cloudlinux.com> - 0.20.0-12.cloudlinux
+- CLOS-6911: Remove SysV runlevel links left over from the old system where the new one provides a real systemd service, which otherwise started the service outside its own unit - MariaDB was affected on servers using CloudLinux MySQL
+
 * Tue Aug 11 2026 Roman Prilipskii <rprilipskii@cloudlinux.com> - 0.20.0-11.cloudlinux
 - CLOS-4518: Fix systemd timers that replace a cron job on the new system being left disabled after the upgrade
 - CLOS-6809: Fix the upgrade being blocked on servers running MySQL Governor with MariaDB 11.4 or 11.8, where the installed database version was reported in a form that the cl-mysql repository check did not recognise

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/actor.py
@@ -1,0 +1,37 @@
+from leapp.actors import Actor
+from leapp.libraries.actor import removestalesysvlinks
+from leapp.libraries.common.cllaunch import run_on_cloudlinux
+from leapp.reporting import Report
+from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+
+
+class RemoveStaleSysvLinks(Actor):
+    """
+    Remove SysV runlevel links that shadow a native systemd unit after the upgrade.
+
+    A package can ship both an init script and a systemd unit, and the runlevel
+    links chkconfig created on the source system belong to no package at all -
+    so nothing removes them during the upgrade. On the target,
+    systemd-sysv-generator turns such a link back into an LSB compatibility unit
+    that races the real one.
+
+    cl-MariaDB103-server is the case this was written for: it ships
+    /etc/rc.d/init.d/mysql on EL9 as well, the EL8 links survive, and MariaDB
+    ends up started by mysqld_safe outside mariadb.service - so
+    'systemctl start mariadb' fails against a server that is already running,
+    and the init script itself is broken on EL9, where log_success_msg no longer
+    exists. leapp's own systemd state transition cannot see any of this: it
+    works on units, and these are files under /etc/rc.d/rc*.d.
+
+    Links whose service has no native unit on the target are left alone, since
+    there the init script is the only way that service runs.
+    """
+
+    name = 'remove_stale_sysv_links'
+    consumes = ()
+    produces = (Report,)
+    tags = (FirstBootPhaseTag, IPUWorkflowTag)
+
+    @run_on_cloudlinux
+    def process(self):
+        removestalesysvlinks.process()

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/actor.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/actor.py
@@ -2,7 +2,7 @@ from leapp.actors import Actor
 from leapp.libraries.actor import removestalesysvlinks
 from leapp.libraries.common.cllaunch import run_on_cloudlinux
 from leapp.reporting import Report
-from leapp.tags import FirstBootPhaseTag, IPUWorkflowTag
+from leapp.tags import FinalizationPhaseTag, IPUWorkflowTag
 
 
 class RemoveStaleSysvLinks(Actor):
@@ -23,14 +23,20 @@ class RemoveStaleSysvLinks(Actor):
     exists. leapp's own systemd state transition cannot see any of this: it
     works on units, and these are files under /etc/rc.d/rc*.d.
 
-    Links whose service has no native unit on the target are left alone, since
+    Links whose service has no real unit on the target are left alone, since
     there the init script is the only way that service runs.
+
+    Runs in FinalizationPhase, against the mounted target root before the new
+    system has booted at all - the same phase leapp's own SetSystemdServicesState
+    uses. On FirstBoot the generator has already turned the links into units and
+    started the services, so removing them then only takes effect one boot later,
+    and the conversion's finish stage fails before that boot happens.
     """
 
     name = 'remove_stale_sysv_links'
     consumes = ()
     produces = (Report,)
-    tags = (FirstBootPhaseTag, IPUWorkflowTag)
+    tags = (FinalizationPhaseTag, IPUWorkflowTag)
 
     @run_on_cloudlinux
     def process(self):

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/libraries/removestalesysvlinks.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/libraries/removestalesysvlinks.py
@@ -10,6 +10,13 @@ FMT_LIST_SEPARATOR = '\n    - '
 RC_DIR_GLOB = '/etc/rc.d/rc{}.d'
 RUNLEVELS = range(0, 7)
 
+# Where a real unit can be shipped or administratively placed. Deliberately NOT
+# /run/systemd: that is where systemd-sysv-generator writes the units it makes
+# FROM the very links this actor removes. Asking a booted system
+# 'is there a <name>.service?' therefore always answers yes for any SysV service
+# with an init script, which makes the check circular and the answer worthless.
+UNIT_DIRS = ['/usr/lib/systemd/system', '/etc/systemd/system']
+
 # S64mysql / K36mysql -> ('S', 'mysql')
 _LINK_RE = re.compile(r'^(?P<action>[SK])(?P<order>[0-9]{2})(?P<name>.+)$')
 
@@ -60,26 +67,80 @@ def collect_sysv_links(rc_dirs=None):
     return links, started_at_boot
 
 
-def select_shadowed_services(links, service_files):
+def scan_unit_providers(unit_dirs=None):
     """
-    Keep only the services whose SysV links are shadowed by a native unit.
+    Map every service name a real unit file provides to the unit providing it.
 
-    A SysV link is only stale when the target system has a real
-    '<name>.service' to take over. Where it does not, the init script is the
-    only way that service runs and the links must be left alone.
+    A unit provides its own name, and also every name it lists as an Alias in
+    its [Install] section - which is how the name a SysV script uses reaches a
+    differently named unit. cl-MariaDB103-server is exactly this shape: it ships
+    /etc/init.d/mysql and mariadb.service, no mysql.service, and mariadb.service
+    carries 'Alias=mysql.service'.
 
-    :return: Dictionary mapping service name to (link paths, unit state)
+    :return: Dictionary mapping a provided service name to the unit file name
+    :rtype: dict[str, str]
+    """
+    providers = {}
+    for unit_dir in unit_dirs if unit_dirs is not None else UNIT_DIRS:
+        try:
+            entries = sorted(os.listdir(unit_dir))
+        except OSError:
+            continue
+        for entry in entries:
+            if not entry.endswith('.service'):
+                continue
+            path = os.path.join(unit_dir, entry)
+            if os.path.islink(path):
+                # An alias symlink an earlier 'systemctl enable' created. The
+                # unit that actually provides the name is its target.
+                providers.setdefault(entry[:-len('.service')],
+                                     os.path.basename(os.readlink(path)))
+                continue
+            if not os.path.isfile(path):
+                continue
+            providers.setdefault(entry[:-len('.service')], entry)
+            for alias in _parse_aliases(path):
+                providers.setdefault(alias, entry)
+    return providers
+
+
+def _parse_aliases(path):
+    """Return the service names a unit file declares as [Install] Alias."""
+    aliases = []
+    section = None
+    try:
+        with open(path) as unit_file:
+            for line in unit_file:
+                line = line.strip()
+                if line.startswith('[') and line.endswith(']'):
+                    section = line[1:-1].lower()
+                    continue
+                if section != 'install' or not line.lower().startswith('alias'):
+                    continue
+                _, _, value = line.partition('=')
+                for name in value.split():
+                    if name.endswith('.service'):
+                        aliases.append(name[:-len('.service')])
+    except (OSError, UnicodeDecodeError):
+        return []
+    return aliases
+
+
+def select_shadowed_services(links, providers):
+    """
+    Keep only the services whose SysV links are shadowed by a real unit.
+
+    A SysV link is only stale when the target system has a real unit to take
+    over. Where it does not, the init script is the only way that service runs
+    and the links must be left alone.
+
+    :return: Dictionary mapping service name to (link paths, unit to enable)
     :rtype: dict[str, tuple[list[str], str]]
     """
-    states = {
-        os.path.basename(service_file.name)[:-len('.service')]: service_file.state
-        for service_file in service_files
-        if service_file.name.endswith('.service')
-    }
     return {
-        name: (paths, states[name])
+        name: (paths, providers[name])
         for name, paths in links.items()
-        if name in states
+        if name in providers
     }
 
 
@@ -88,23 +149,30 @@ def process():
     if not links:
         return
 
-    shadowed = select_shadowed_services(links, systemd.get_service_files())
+    shadowed = select_shadowed_services(links, scan_unit_providers())
     if not shadowed:
         return
 
     removed = []
     enabled = []
-    for name, (paths, state) in sorted(shadowed.items()):
+    for name, (paths, unit) in sorted(shadowed.items()):
         # The SysV link was what started this service at boot, so hand that
-        # intent to the native unit before taking the link away. Without this
-        # the service would simply stop being started.
-        if name in started_at_boot and state != 'enabled':
+        # intent to the real unit before taking the link away. Without this the
+        # service would simply stop being started.
+        #
+        # The unit, never '<name>.service': on the name a SysV script uses,
+        # 'systemctl enable' finds no native unit, reports 'redirecting to
+        # systemd-sysv-install' and calls chkconfig, which RE-CREATES the very
+        # links being removed. Enabling is idempotent, so this does not need to
+        # know whether the unit was already enabled - which cannot be read
+        # reliably against a target that is not running yet.
+        if name in started_at_boot:
             try:
-                systemd.enable_unit('{}.service'.format(name))
-                enabled.append(name)
+                systemd.enable_unit(unit)
+                enabled.append(unit)
             except CalledProcessError as err:
                 api.current_logger().warning(
-                    'Failed to enable {}.service, leaving its SysV links in place: {}'.format(name, err)
+                    'Failed to enable {}, leaving the SysV links for {} in place: {}'.format(unit, name, err)
                 )
                 continue
 

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/libraries/removestalesysvlinks.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/libraries/removestalesysvlinks.py
@@ -1,0 +1,147 @@
+import os
+import re
+
+from leapp import reporting
+from leapp.libraries.common import systemd
+from leapp.libraries.stdlib import api, CalledProcessError
+
+FMT_LIST_SEPARATOR = '\n    - '
+
+RC_DIR_GLOB = '/etc/rc.d/rc{}.d'
+RUNLEVELS = range(0, 7)
+
+# S64mysql / K36mysql -> ('S', 'mysql')
+_LINK_RE = re.compile(r'^(?P<action>[SK])(?P<order>[0-9]{2})(?P<name>.+)$')
+
+
+def _rc_dirs():
+    return [RC_DIR_GLOB.format(runlevel) for runlevel in RUNLEVELS]
+
+
+def parse_link_name(filename):
+    """
+    Split a SysV runlevel link name into its start/stop action and service name.
+
+    :return: (action, service name), or None when the name is not a runlevel link
+    :rtype: tuple[str, str] | None
+    """
+    match = _LINK_RE.match(filename)
+    if not match:
+        return None
+    return match.group('action'), match.group('name')
+
+
+def collect_sysv_links(rc_dirs=None):
+    """
+    Find the SysV runlevel links present on the system.
+
+    :return: Dictionary mapping a service name to the list of link paths, and a
+             set of the service names that have at least one start link
+    :rtype: tuple[dict[str, list[str]], set[str]]
+    """
+    links = {}
+    started_at_boot = set()
+    for rc_dir in rc_dirs if rc_dirs is not None else _rc_dirs():
+        try:
+            entries = os.listdir(rc_dir)
+        except OSError:
+            continue
+        for entry in entries:
+            path = os.path.join(rc_dir, entry)
+            if not os.path.islink(path):
+                continue
+            parsed = parse_link_name(entry)
+            if parsed is None:
+                continue
+            action, name = parsed
+            links.setdefault(name, []).append(path)
+            if action == 'S':
+                started_at_boot.add(name)
+    return links, started_at_boot
+
+
+def select_shadowed_services(links, service_files):
+    """
+    Keep only the services whose SysV links are shadowed by a native unit.
+
+    A SysV link is only stale when the target system has a real
+    '<name>.service' to take over. Where it does not, the init script is the
+    only way that service runs and the links must be left alone.
+
+    :return: Dictionary mapping service name to (link paths, unit state)
+    :rtype: dict[str, tuple[list[str], str]]
+    """
+    states = {
+        os.path.basename(service_file.name)[:-len('.service')]: service_file.state
+        for service_file in service_files
+        if service_file.name.endswith('.service')
+    }
+    return {
+        name: (paths, states[name])
+        for name, paths in links.items()
+        if name in states
+    }
+
+
+def process():
+    links, started_at_boot = collect_sysv_links()
+    if not links:
+        return
+
+    shadowed = select_shadowed_services(links, systemd.get_service_files())
+    if not shadowed:
+        return
+
+    removed = []
+    enabled = []
+    for name, (paths, state) in sorted(shadowed.items()):
+        # The SysV link was what started this service at boot, so hand that
+        # intent to the native unit before taking the link away. Without this
+        # the service would simply stop being started.
+        if name in started_at_boot and state != 'enabled':
+            try:
+                systemd.enable_unit('{}.service'.format(name))
+                enabled.append(name)
+            except CalledProcessError as err:
+                api.current_logger().warning(
+                    'Failed to enable {}.service, leaving its SysV links in place: {}'.format(name, err)
+                )
+                continue
+
+        for path in sorted(paths):
+            try:
+                os.unlink(path)
+            except OSError as err:
+                api.current_logger().warning(
+                    'Failed to remove stale SysV link {}: {}'.format(path, err)
+                )
+                continue
+            removed.append(path)
+
+    if not removed:
+        return
+
+    api.current_logger().info('Removed stale SysV runlevel links: {}'.format(', '.join(removed)))
+
+    summary = (
+        'The following SysV runlevel links were left over from the previous major version'
+        ' while the upgraded system provides a native systemd unit for the same service.'
+        ' systemd-sysv-generator turns such a link back into a unit, which then races the'
+        ' real one - the service ends up started outside its own unit, and'
+        ' "systemctl start <name>" fails against a server that is already running.'
+        ' They have been removed:{}{}'.format(FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(removed))
+    )
+    if enabled:
+        summary += (
+            '\n\nThe native units below were enabled first, so the services keep starting'
+            ' at boot as their SysV links used to arrange:{}{}'.format(
+                FMT_LIST_SEPARATOR, FMT_LIST_SEPARATOR.join(sorted(enabled))
+            )
+        )
+
+    reporting.create_report([
+        reporting.Title('Stale SysV runlevel links were removed'),
+        reporting.Summary(summary),
+        reporting.Severity(reporting.Severity.MEDIUM),
+        reporting.Groups([reporting.Groups.SERVICES]),
+    ])

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/tests/test_removestalesysvlinks.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/tests/test_removestalesysvlinks.py
@@ -1,0 +1,168 @@
+import os
+
+import pytest
+
+from leapp import reporting
+from leapp.libraries.actor import removestalesysvlinks
+from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
+from leapp.libraries.stdlib import api, CalledProcessError
+from leapp.models import SystemdServiceFile
+
+
+def _make_rc_dirs(tmpdir, links):
+    """
+    Build /etc/rc.d/rc<N>.d trees under tmpdir.
+
+    :param links: mapping of runlevel -> list of link names
+    :return: list of the rc directories created
+    """
+    init_d = tmpdir.mkdir('init.d')
+    rc_dirs = []
+    for runlevel, names in sorted(links.items()):
+        rc_dir = tmpdir.mkdir('rc{}.d'.format(runlevel))
+        rc_dirs.append(str(rc_dir))
+        for name in names:
+            parsed = removestalesysvlinks.parse_link_name(name)
+            target = init_d.join(parsed[1] if parsed else name)
+            if not target.check():
+                target.write('#!/bin/sh\n')
+            os.symlink(str(target), str(rc_dir.join(name)))
+    return rc_dirs
+
+
+class TestParseLinkName(object):
+    def test_start_link(self):
+        # Exactly the shape cl-MariaDB103-server leaves behind.
+        assert removestalesysvlinks.parse_link_name('S64mysql') == ('S', 'mysql')
+
+    def test_kill_link(self):
+        assert removestalesysvlinks.parse_link_name('K36mysql') == ('K', 'mysql')
+
+    def test_name_with_digits(self):
+        assert removestalesysvlinks.parse_link_name('S80postgresql-13') == ('S', 'postgresql-13')
+
+    @pytest.mark.parametrize('name', ['README', 'mysql', 'S6mysql', 'X64mysql', 'S64'])
+    def test_not_a_runlevel_link(self, name):
+        assert removestalesysvlinks.parse_link_name(name) is None
+
+
+class TestCollectSysvLinks(object):
+    def test_collects_links_and_notes_start_at_boot(self, tmpdir):
+        rc_dirs = _make_rc_dirs(tmpdir, {0: ['K36mysql'], 3: ['S64mysql'], 5: ['S64mysql']})
+        links, started = removestalesysvlinks.collect_sysv_links(rc_dirs)
+        assert sorted(links) == ['mysql']
+        assert len(links['mysql']) == 3
+        assert started == {'mysql'}
+
+    def test_a_service_with_only_kill_links_does_not_start_at_boot(self, tmpdir):
+        rc_dirs = _make_rc_dirs(tmpdir, {0: ['K36mysql'], 6: ['K36mysql']})
+        links, started = removestalesysvlinks.collect_sysv_links(rc_dirs)
+        assert sorted(links) == ['mysql']
+        assert started == set()
+
+    def test_missing_directories_are_not_an_error(self, tmpdir):
+        links, started = removestalesysvlinks.collect_sysv_links([str(tmpdir.join('absent'))])
+        assert links == {}
+        assert started == set()
+
+    def test_plain_files_are_ignored(self, tmpdir):
+        rc_dir = tmpdir.mkdir('rc3.d')
+        rc_dir.join('S64mysql').write('not a symlink')
+        links, _ = removestalesysvlinks.collect_sysv_links([str(rc_dir)])
+        assert links == {}
+
+
+class TestSelectShadowedServices(object):
+    def test_selects_a_service_with_a_native_unit(self):
+        links = {'mysql': ['/etc/rc.d/rc3.d/S64mysql']}
+        service_files = [SystemdServiceFile(name='mariadb.service', state='enabled'),
+                         SystemdServiceFile(name='mysql.service', state='alias')]
+        selected = removestalesysvlinks.select_shadowed_services(links, service_files)
+        assert selected == {'mysql': (['/etc/rc.d/rc3.d/S64mysql'], 'alias')}
+
+    def test_leaves_a_service_with_no_native_unit_alone(self):
+        # Without a unit to take over, the init script is the only way that
+        # service runs - removing its links would simply stop it starting.
+        links = {'drwebd': ['/etc/rc.d/rc3.d/S20drwebd']}
+        service_files = [SystemdServiceFile(name='mariadb.service', state='enabled')]
+        assert removestalesysvlinks.select_shadowed_services(links, service_files) == {}
+
+    def test_non_service_units_do_not_shadow(self):
+        links = {'mysql': ['/etc/rc.d/rc3.d/S64mysql']}
+        service_files = [SystemdServiceFile(name='mysql.timer', state='enabled')]
+        assert removestalesysvlinks.select_shadowed_services(links, service_files) == {}
+
+
+class TestProcess(object):
+    def _setup(self, monkeypatch, tmpdir, links, service_files, enable_raises=False):
+        rc_dirs = _make_rc_dirs(tmpdir, links)
+        monkeypatch.setattr(removestalesysvlinks, '_rc_dirs', lambda: rc_dirs)
+        monkeypatch.setattr(removestalesysvlinks.systemd, 'get_service_files',
+                            lambda: service_files)
+        self.enabled = []
+
+        def _enable(unit):
+            if enable_raises:
+                raise CalledProcessError('boom', ['systemctl', 'enable', unit], {})
+            self.enabled.append(unit)
+
+        monkeypatch.setattr(removestalesysvlinks.systemd, 'enable_unit', _enable)
+        monkeypatch.setattr(api, 'current_logger', logger_mocked())
+        monkeypatch.setattr(reporting, 'create_report', create_report_mocked())
+        return rc_dirs
+
+    def test_removes_the_links_and_reports(self, monkeypatch, tmpdir):
+        rc_dirs = self._setup(
+            monkeypatch, tmpdir,
+            {0: ['K36mysql'], 3: ['S64mysql']},
+            [SystemdServiceFile(name='mysql.service', state='enabled')])
+        removestalesysvlinks.process()
+        for rc_dir in rc_dirs:
+            assert os.listdir(rc_dir) == []
+        assert reporting.create_report.called == 1
+        assert 'S64mysql' in reporting.create_report.report_fields['summary']
+
+    def test_enables_the_unit_before_taking_the_start_link_away(self, monkeypatch, tmpdir):
+        # The SysV link was what started the service at boot; that intent has to
+        # move to the native unit or the service silently stops starting.
+        self._setup(monkeypatch, tmpdir, {3: ['S64mysql']},
+                    [SystemdServiceFile(name='mysql.service', state='disabled')])
+        removestalesysvlinks.process()
+        assert self.enabled == ['mysql.service']
+
+    def test_does_not_enable_a_unit_that_is_already_enabled(self, monkeypatch, tmpdir):
+        self._setup(monkeypatch, tmpdir, {3: ['S64mysql']},
+                    [SystemdServiceFile(name='mysql.service', state='enabled')])
+        removestalesysvlinks.process()
+        assert self.enabled == []
+
+    def test_does_not_enable_for_kill_links_only(self, monkeypatch, tmpdir):
+        self._setup(monkeypatch, tmpdir, {0: ['K36mysql']},
+                    [SystemdServiceFile(name='mysql.service', state='disabled')])
+        removestalesysvlinks.process()
+        assert self.enabled == []
+
+    def test_keeps_the_links_when_the_unit_cannot_be_enabled(self, monkeypatch, tmpdir):
+        # Removing them after a failed enable would leave the service started by
+        # nothing at all, which is worse than the shadowing being fixed.
+        rc_dirs = self._setup(
+            monkeypatch, tmpdir, {3: ['S64mysql']},
+            [SystemdServiceFile(name='mysql.service', state='disabled')],
+            enable_raises=True)
+        removestalesysvlinks.process()
+        assert os.listdir(rc_dirs[0]) == ['S64mysql']
+        assert reporting.create_report.called == 0
+
+    def test_leaves_unshadowed_links_in_place(self, monkeypatch, tmpdir):
+        rc_dirs = self._setup(
+            monkeypatch, tmpdir, {3: ['S20drwebd']},
+            [SystemdServiceFile(name='mariadb.service', state='enabled')])
+        removestalesysvlinks.process()
+        assert os.listdir(rc_dirs[0]) == ['S20drwebd']
+        assert reporting.create_report.called == 0
+
+    def test_says_nothing_when_there_are_no_links(self, monkeypatch, tmpdir):
+        self._setup(monkeypatch, tmpdir, {},
+                    [SystemdServiceFile(name='mariadb.service', state='enabled')])
+        removestalesysvlinks.process()
+        assert reporting.create_report.called == 0

--- a/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/tests/test_removestalesysvlinks.py
+++ b/repos/system_upgrade/cloudlinux/actors/removestalesysvlinks/tests/test_removestalesysvlinks.py
@@ -6,7 +6,6 @@ from leapp import reporting
 from leapp.libraries.actor import removestalesysvlinks
 from leapp.libraries.common.testutils import create_report_mocked, logger_mocked
 from leapp.libraries.stdlib import api, CalledProcessError
-from leapp.models import SystemdServiceFile
 
 
 def _make_rc_dirs(tmpdir, links):
@@ -72,33 +71,84 @@ class TestCollectSysvLinks(object):
         assert links == {}
 
 
-class TestSelectShadowedServices(object):
-    def test_selects_a_service_with_a_native_unit(self):
-        links = {'mysql': ['/etc/rc.d/rc3.d/S64mysql']}
-        service_files = [SystemdServiceFile(name='mariadb.service', state='enabled'),
-                         SystemdServiceFile(name='mysql.service', state='alias')]
-        selected = removestalesysvlinks.select_shadowed_services(links, service_files)
-        assert selected == {'mysql': (['/etc/rc.d/rc3.d/S64mysql'], 'alias')}
+def _write_units(tmpdir, units):
+    """Create real unit FILES. units maps filename -> file body (or a symlink target)."""
+    unit_dir = tmpdir.mkdir('units')
+    for name, body in units.items():
+        target = unit_dir.join(name)
+        if body.startswith('->'):
+            os.symlink(body[2:].strip(), str(target))
+        else:
+            target.write(body)
+    return str(unit_dir)
 
-    def test_leaves_a_service_with_no_native_unit_alone(self):
+
+# The real cl-MariaDB103-server shape: an init script and mariadb.service, no
+# mysql.service of its own, the SysV name reached only through the alias.
+MARIADB_UNIT = (
+    '[Unit]\nDescription=MariaDB database server\n'
+    '[Service]\nExecStart=/usr/sbin/mysqld\n'
+    '[Install]\nWantedBy=multi-user.target\nAlias=mysql.service\nAlias=mysqld.service\n'
+)
+
+
+class TestScanUnitProviders(object):
+    def test_a_unit_provides_its_own_name(self, tmpdir):
+        unit_dir = _write_units(tmpdir, {'drwebd.service': '[Unit]\n'})
+        assert removestalesysvlinks.scan_unit_providers([unit_dir]) == {
+            'drwebd': 'drwebd.service'}
+
+    def test_a_unit_provides_the_names_it_aliases(self, tmpdir):
+        # Without this the mysql links are never matched at all and the actor
+        # silently does nothing in the one case it exists for.
+        unit_dir = _write_units(tmpdir, {'mariadb.service': MARIADB_UNIT})
+        providers = removestalesysvlinks.scan_unit_providers([unit_dir])
+        assert providers['mysql'] == 'mariadb.service'
+        assert providers['mysqld'] == 'mariadb.service'
+        assert providers['mariadb'] == 'mariadb.service'
+
+    def test_an_alias_outside_the_install_section_is_not_a_provider(self, tmpdir):
+        unit_dir = _write_units(tmpdir, {
+            'x.service': '[Unit]\nAlias=notreally.service\n[Install]\nWantedBy=x\n'})
+        assert 'notreally' not in removestalesysvlinks.scan_unit_providers([unit_dir])
+
+    def test_an_alias_symlink_resolves_to_its_target(self, tmpdir):
+        unit_dir = _write_units(tmpdir, {'mariadb.service': MARIADB_UNIT,
+                                         'mysql.service': '-> mariadb.service'})
+        assert removestalesysvlinks.scan_unit_providers([unit_dir])['mysql'] == 'mariadb.service'
+
+    def test_a_missing_directory_is_not_an_error(self, tmpdir):
+        assert removestalesysvlinks.scan_unit_providers([str(tmpdir.join('absent'))]) == {}
+
+    def test_generator_output_is_never_consulted(self):
+        # systemd-sysv-generator writes under /run/systemd, and it writes units
+        # made FROM the links this actor removes. Reading those back makes the
+        # 'is there a real unit?' test answer yes for every SysV service, which
+        # is how the actor came to remove links for services that had no unit
+        # and to enable a name that redirected straight back into chkconfig.
+        assert not [d for d in removestalesysvlinks.UNIT_DIRS if d.startswith('/run')]
+
+
+class TestSelectShadowedServices(object):
+    def test_selects_a_service_reached_through_an_alias(self):
+        links = {'mysql': ['/etc/rc.d/rc3.d/S64mysql']}
+        providers = {'mysql': 'mariadb.service', 'mariadb': 'mariadb.service'}
+        assert removestalesysvlinks.select_shadowed_services(links, providers) == {
+            'mysql': (['/etc/rc.d/rc3.d/S64mysql'], 'mariadb.service')}
+
+    def test_leaves_a_service_with_no_real_unit_alone(self):
         # Without a unit to take over, the init script is the only way that
         # service runs - removing its links would simply stop it starting.
         links = {'drwebd': ['/etc/rc.d/rc3.d/S20drwebd']}
-        service_files = [SystemdServiceFile(name='mariadb.service', state='enabled')]
-        assert removestalesysvlinks.select_shadowed_services(links, service_files) == {}
-
-    def test_non_service_units_do_not_shadow(self):
-        links = {'mysql': ['/etc/rc.d/rc3.d/S64mysql']}
-        service_files = [SystemdServiceFile(name='mysql.timer', state='enabled')]
-        assert removestalesysvlinks.select_shadowed_services(links, service_files) == {}
+        assert removestalesysvlinks.select_shadowed_services(links, {'mariadb': 'mariadb.service'}) == {}
 
 
 class TestProcess(object):
-    def _setup(self, monkeypatch, tmpdir, links, service_files, enable_raises=False):
+    def _setup(self, monkeypatch, tmpdir, links, units, enable_raises=False):
         rc_dirs = _make_rc_dirs(tmpdir, links)
+        unit_dir = _write_units(tmpdir, units)
         monkeypatch.setattr(removestalesysvlinks, '_rc_dirs', lambda: rc_dirs)
-        monkeypatch.setattr(removestalesysvlinks.systemd, 'get_service_files',
-                            lambda: service_files)
+        monkeypatch.setattr(removestalesysvlinks, 'UNIT_DIRS', [unit_dir])
         self.enabled = []
 
         def _enable(unit):
@@ -112,57 +162,90 @@ class TestProcess(object):
         return rc_dirs
 
     def test_removes_the_links_and_reports(self, monkeypatch, tmpdir):
-        rc_dirs = self._setup(
-            monkeypatch, tmpdir,
-            {0: ['K36mysql'], 3: ['S64mysql']},
-            [SystemdServiceFile(name='mysql.service', state='enabled')])
+        rc_dirs = self._setup(monkeypatch, tmpdir,
+                              {0: ['K36mysql'], 3: ['S64mysql']},
+                              {'mariadb.service': MARIADB_UNIT})
         removestalesysvlinks.process()
         for rc_dir in rc_dirs:
             assert os.listdir(rc_dir) == []
         assert reporting.create_report.called == 1
         assert 'S64mysql' in reporting.create_report.report_fields['summary']
 
-    def test_enables_the_unit_before_taking_the_start_link_away(self, monkeypatch, tmpdir):
-        # The SysV link was what started the service at boot; that intent has to
-        # move to the native unit or the service silently stops starting.
+    def test_enables_the_unit_not_the_sysv_name(self, monkeypatch, tmpdir):
+        # Enabling 'mysql.service' finds no native unit, reports 'redirecting to
+        # systemd-sysv-install' and calls chkconfig, which puts the links back.
         self._setup(monkeypatch, tmpdir, {3: ['S64mysql']},
-                    [SystemdServiceFile(name='mysql.service', state='disabled')])
+                    {'mariadb.service': MARIADB_UNIT})
         removestalesysvlinks.process()
-        assert self.enabled == ['mysql.service']
-
-    def test_does_not_enable_a_unit_that_is_already_enabled(self, monkeypatch, tmpdir):
-        self._setup(monkeypatch, tmpdir, {3: ['S64mysql']},
-                    [SystemdServiceFile(name='mysql.service', state='enabled')])
-        removestalesysvlinks.process()
-        assert self.enabled == []
+        assert self.enabled == ['mariadb.service']
 
     def test_does_not_enable_for_kill_links_only(self, monkeypatch, tmpdir):
         self._setup(monkeypatch, tmpdir, {0: ['K36mysql']},
-                    [SystemdServiceFile(name='mysql.service', state='disabled')])
+                    {'mariadb.service': MARIADB_UNIT})
         removestalesysvlinks.process()
         assert self.enabled == []
 
     def test_keeps_the_links_when_the_unit_cannot_be_enabled(self, monkeypatch, tmpdir):
         # Removing them after a failed enable would leave the service started by
         # nothing at all, which is worse than the shadowing being fixed.
-        rc_dirs = self._setup(
-            monkeypatch, tmpdir, {3: ['S64mysql']},
-            [SystemdServiceFile(name='mysql.service', state='disabled')],
-            enable_raises=True)
+        rc_dirs = self._setup(monkeypatch, tmpdir, {3: ['S64mysql']},
+                              {'mariadb.service': MARIADB_UNIT}, enable_raises=True)
         removestalesysvlinks.process()
         assert os.listdir(rc_dirs[0]) == ['S64mysql']
         assert reporting.create_report.called == 0
 
     def test_leaves_unshadowed_links_in_place(self, monkeypatch, tmpdir):
-        rc_dirs = self._setup(
-            monkeypatch, tmpdir, {3: ['S20drwebd']},
-            [SystemdServiceFile(name='mariadb.service', state='enabled')])
+        rc_dirs = self._setup(monkeypatch, tmpdir, {3: ['S20drwebd']},
+                              {'mariadb.service': MARIADB_UNIT})
         removestalesysvlinks.process()
         assert os.listdir(rc_dirs[0]) == ['S20drwebd']
         assert reporting.create_report.called == 0
 
     def test_says_nothing_when_there_are_no_links(self, monkeypatch, tmpdir):
-        self._setup(monkeypatch, tmpdir, {},
-                    [SystemdServiceFile(name='mariadb.service', state='enabled')])
+        self._setup(monkeypatch, tmpdir, {}, {'mariadb.service': MARIADB_UNIT})
         removestalesysvlinks.process()
         assert reporting.create_report.called == 0
+
+
+class TestActorPhase(object):
+    """The links have to be gone BEFORE the new system boots, not after.
+
+    systemd-sysv-generator runs at every boot and turns a surviving runlevel
+    link into a unit, which then starts the service. On a FirstBoot actor the
+    generator has already done that by the time the actor runs: the database
+    comes up under the generated mysql.service early in the boot, the actor
+    removes the links a minute later, and the conversion's finish stage then
+    fails on 'systemctl start mariadb.service' against a datadir that is
+    already in use. The removal only takes effect on the SECOND boot, which a
+    failed finish stage never reaches.
+
+    Observed on a CloudLinux 8 + Plesk conversion: mysqld_safe as PID 1585
+    under /system.slice/mysql.service, and
+
+        mariadb.service: Unit process 1585 (mysqld_safe) remains running
+        Failed to start MariaDB database server.
+
+    FinalizationPhase runs in the upgrade initramfs against the mounted target
+    root, before any boot of the new system. It is where leapp's own
+    SetSystemdServicesState applies unit states, for the same reason.
+    """
+
+    def _declared_tags(self):
+        import ast
+        import os
+        actor_py = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), 'actor.py')
+        tree = ast.parse(open(actor_py).read())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign) and any(
+                    getattr(t, 'id', None) == 'tags' for t in node.targets):
+                return {getattr(e, 'id', getattr(e, 'attr', None))
+                        for e in getattr(node.value, 'elts', [])}
+        raise AssertionError('the actor declares no tags')
+
+    def test_runs_in_finalization(self):
+        assert 'FinalizationPhaseTag' in self._declared_tags()
+
+    def test_does_not_run_on_first_boot(self):
+        # By then systemd-sysv-generator has already started the service.
+        assert 'FirstBootPhaseTag' not in self._declared_tags()

--- a/utils/check-spec-release.py
+++ b/utils/check-spec-release.py
@@ -96,13 +96,34 @@ def main():
         return 1
 
     # 1. the Makefile must report the spec's release
-    proc = subprocess.run(["make", "print_release"], capture_output=True, text=True)
+    #
+    # This runs as a CHILD of make (`make lint-spec-release` -> this script ->
+    # `make print_release`), so the nested make inherits MAKELEVEL and prints
+    # "Entering directory"/"Leaving directory" around the value. Taking the last
+    # line then compared the release against make's own chatter and failed every
+    # pull request:
+    #
+    #     make print_release: make[1]: Leaving directory '/home/runner/...'
+    #
+    # --no-print-directory suppresses them and wins over an inherited `-w`.
+    # The environment is deliberately NOT scrubbed: dropping MAKEFLAGS would
+    # also drop command-line variable overrides, and a `make RELEASE=...`
+    # reaching the build unnoticed is precisely what this check is for.
+    proc = subprocess.run(["make", "--no-print-directory", "print_release"],
+                          capture_output=True, text=True)
     if proc.returncode != 0:
         print("ERROR: `make print_release` failed:\n{0}".format(
             (proc.stderr or proc.stdout).strip()), file=sys.stderr)
         return 1
-    reported = (proc.stdout or "").strip().splitlines()
-    reported = reported[-1].strip() if reported else ""
+    # Exactly one line is expected. Say so rather than picking one, so that
+    # anything unforeseen in the output is a legible error instead of a
+    # comparison against the wrong string.
+    lines = [ln.strip() for ln in (proc.stdout or "").splitlines() if ln.strip()]
+    if len(lines) != 1:
+        print("ERROR: `make print_release` printed {0} lines, expected 1:\n{1}".format(
+            len(lines), (proc.stdout or "").strip() or "(nothing)"), file=sys.stderr)
+        return 1
+    reported = lines[0]
     if reported != declared:
         failed = True
         print("ERROR: the build would not ship the declared release.", file=sys.stderr)


### PR DESCRIPTION
## What

Adds `RemoveStaleSysvLinks`, a Finalization-phase actor that removes SysV runlevel links left over from the source system where the target provides a real systemd unit for the same service.

## Why

A package can ship both an init script and a systemd unit. The runlevel links `chkconfig` created on the source system belong to **no package**, so nothing removes them during the upgrade. On the target, `systemd-sysv-generator` turns such a link back into a unit that contests with the real one.

`cl-MariaDB103-server` is the case this was written for. It ships `/etc/init.d/mysql` on EL9 as well, the EL8 links survive, and MariaDB ends up started by `mysqld_safe` outside `mariadb.service`:

    CGroup: /system.slice/mysql.service
      |- 1585 /usr/bin/sh /usr/bin/mysqld_safe
    mariadb.service: Unit process 1585 (mysqld_safe) remains running
    Failed to start MariaDB database server.

The init script is itself broken on EL9, where `log_success_msg` no longer exists.

leapp's own systemd state transition cannot see any of this. It works on units, and these are files under `/etc/rc.d/rc*.d` - the same blind spot as CLOS-4518, which was the `.timer` half of `_SYSTEMCTL_CMD_OPTIONS = ['--type=service', ...]`. This is the SysV half.

## Two important aspects

**It has to run before the target boots.** On FirstBoot the generator has already read the links and started the service - PID 1585 above is early boot. The removal then only takes effect on the *second* boot, and a conversion whose finish stage fails never reaches it. `FinalizationPhase` runs in the upgrade initramfs against the mounted target root, which is where leapp's own `SetSystemdServicesState` applies unit states for the same reason.

**"Is there a real unit?" must not be asked of a booted system.** `systemctl list-unit-files` includes generator output - a unit generated from the link being removed - so the check is circular and answers yes for any SysV service with an init script. It also made the enable step actively harmful: `cl-MariaDB103-server` ships no `mysql.service`, so `systemctl enable mysql.service` reported "not a native service, redirecting to systemd-sysv-install" and called `chkconfig`, which re-creates the links.

Units are therefore read from files in `/usr/lib/systemd/system` and `/etc/systemd/system` - never `/run/systemd`, where the generator writes - and a unit provides its own name plus every name in its `[Install] Alias`. `mariadb.service` carries `Alias=mysql.service`, which is how the SysV name reaches the real unit, and that unit is what gets enabled.

Fixing only the phase would break it the other way: with no boot yet there is no generator output, no `mysql.service` appears, and the actor silently leaves the links alone in exactly the case it exists for.

## Behavior

- Only removes links whose service has a real unit on the target. Where there is none, the init script is the only way that service runs, so the links are left alone.
- If a start link existed, the real unit is **enabled first** - the administrator's intent that the service starts at boot has to move to the unit, or the service silently stops starting.
- If enabling fails, the links are kept. Removing them after a failed enable would leave the service started by nothing at all.
- Reports what it removed; says nothing when there is nothing to do.

## Scope

Narrower than it may look.

    cl-MariaDB103-server   SHIPS /etc/init.d/mysql
    cl-MariaDB106-server   no init script
    cl-MariaDB1011-server  no init script
    cl-MySQL80-server      no init script

Only cl-MariaDB103 ships one, so only hosts running it are affected. That is not a rare configuration: EL8's default `mariadb` module stream is 10.3 and MySQL Governor's `auto` follows it, so hosts **arrive** on cl-MariaDB103 without choosing it, and leapp maps the stream 1:1 across the upgrade.

## Notes

- No upstream equivalent exists at the moment. The underlying problem is not CloudLinux-specific in principle - any distro with a package shipping both an init script and a unit can hit it, so it may be worth offering upstream.